### PR TITLE
Support configuring the worker VM name

### DIFF
--- a/terraform/modules/host/main.tf
+++ b/terraform/modules/host/main.tf
@@ -185,7 +185,7 @@ module "worker_module" {
   network_cidr    = var.cluster_network_cidr
 
   # Worker node specific variables #
-  vm_name              = "${var.cluster_name}-${var.node_types.worker}-${each.value.id}"
+  vm_name              = each.value.name != null ? "${var.cluster_name}-${each.value.name}" : "${var.cluster_name}-${var.node_types.worker}-${each.value.id}"
   vm_type              = var.node_types.worker
   vm_user              = var.cluster_nodeTemplate_user
   vm_update            = var.cluster_nodeTemplate_updateOnBoot

--- a/terraform/modules/host/variables.tf
+++ b/terraform/modules/host/variables.tf
@@ -238,6 +238,7 @@ variable "cluster_nodes_worker_default_dataDisks" {
 variable "cluster_nodes_worker_instances" {
   type = list(object({
     id           = number
+    name         = optional(string)
     host         = optional(string)
     mac          = optional(string)
     ip           = optional(string)


### PR DESCRIPTION
Implements https://github.com/MusicDin/kubitect/issues/32

Configured with `cluster.nodes.worker.instances.[].name`.