### PR TITLE
Extra bridges

### DIFF
--- a/terraform/modules/host/main.tf
+++ b/terraform/modules/host/main.tf
@@ -106,7 +106,7 @@ module "lb_module" {
   vm_id                = each.value.id
   vm_mac               = each.value.mac
   vm_ip                = each.value.ip
-  extra_bridges        = []
+  vm_extra_bridges     = []
 
   # Dependancy takes care that resource pool is not removed before volumes are #
   # Also network must be created before VM is initialized #
@@ -154,7 +154,7 @@ module "master_module" {
   vm_id                = each.value.id
   vm_mac               = each.value.mac
   vm_ip                = each.value.ip
-  extra_bridges        = []
+  vm_extra_bridges     = []
 
   # Dependancy takes care that resource pool is not removed before volumes are #
   # Also network must be created before VM is initialized #
@@ -202,7 +202,7 @@ module "worker_module" {
   vm_id                = each.value.id
   vm_mac               = each.value.mac
   vm_ip                = each.value.ip
-  extra_bridges        = each.value.extraBridges
+  vm_extra_bridges     = each.value.extraBridges
 
   # Dependancy takes care that resource pool is not removed before volumes are #
   # Also network must be created before VM is initialized #

--- a/terraform/modules/host/main.tf
+++ b/terraform/modules/host/main.tf
@@ -106,6 +106,7 @@ module "lb_module" {
   vm_id                = each.value.id
   vm_mac               = each.value.mac
   vm_ip                = each.value.ip
+  extra_bridges        = []
 
   # Dependancy takes care that resource pool is not removed before volumes are #
   # Also network must be created before VM is initialized #
@@ -153,6 +154,7 @@ module "master_module" {
   vm_id                = each.value.id
   vm_mac               = each.value.mac
   vm_ip                = each.value.ip
+  extra_bridges        = []
 
   # Dependancy takes care that resource pool is not removed before volumes are #
   # Also network must be created before VM is initialized #
@@ -200,6 +202,7 @@ module "worker_module" {
   vm_id                = each.value.id
   vm_mac               = each.value.mac
   vm_ip                = each.value.ip
+  extra_bridges        = each.value.extraBridges
 
   # Dependancy takes care that resource pool is not removed before volumes are #
   # Also network must be created before VM is initialized #

--- a/terraform/modules/host/variables.tf
+++ b/terraform/modules/host/variables.tf
@@ -249,6 +249,11 @@ variable "cluster_nodes_worker_instances" {
       pool : string
       size : number
     })))
+    extraBridges = optional(list(object({
+      bridge            : string
+      networkInterface  : string
+      ipCidr            : string
+    })))
   }))
   description = "Worker node instances."
 }

--- a/terraform/modules/vm/variables.tf
+++ b/terraform/modules/vm/variables.tf
@@ -51,17 +51,6 @@ variable "network_cidr" {
   description = "Network CIDR"
 }
 
-variable "extra_bridges" {
-  type = list(object({
-    bridge           = string
-    networkInterface = string
-    ipCidr           = string
-  }))
-  description = "Additional network bridges."
-  nullable = false
-  default  = []
-}
-
 # ==================================== #
 # VM variables                         #
 # ==================================== #
@@ -159,4 +148,15 @@ variable "vm_mac" {
 variable "vm_ip" {
   type        = string
   description = "The IP address of the virtual machine"
+}
+
+variable "vm_extra_bridges" {
+  type = list(object({
+    bridge           = string
+    networkInterface = string
+    ipCidr           = string
+  }))
+  description = "Additional network bridges."
+  nullable = false
+  default  = []
 }

--- a/terraform/modules/vm/variables.tf
+++ b/terraform/modules/vm/variables.tf
@@ -51,6 +51,17 @@ variable "network_cidr" {
   description = "Network CIDR"
 }
 
+variable "extra_bridges" {
+  type = list(object({
+    bridge           = string
+    networkInterface = string
+    ipCidr           = string
+  }))
+  description = "Additional network bridges."
+  nullable = false
+  default  = []
+}
+
 # ==================================== #
 # VM variables                         #
 # ==================================== #

--- a/terraform/modules/vm/vm.tf
+++ b/terraform/modules/vm/vm.tf
@@ -11,20 +11,20 @@ data "local_file" "ssh_public_key" {
   filename = "${var.vm_ssh_private_key}.pub"
 }
 
-# Network bridge configuration (for cloud-init) #
-data "template_file" "cloud_init_network_tpl" {
-  template = file(var.vm_ip != null
-    ? "./templates/cloud_init/cloud_init_network_static.tpl"
-    : "./templates/cloud_init/cloud_init_network_dhcp.tpl"
-  )
+locals {
+  # Network bridge configuration (for cloud-init) #
+  vm_dns_list       = length(var.vm_dns) == 0 ? var.network_gateway : join(", ", var.vm_dns)
 
-  vars = {
-    network_interface = var.vm_network_interface
-    network_bridge    = var.network_bridge
-    network_gateway   = var.network_gateway
-    vm_dns_list       = length(var.vm_dns) == 0 ? var.network_gateway : join(", ", var.vm_dns)
-    vm_cidr           = var.vm_ip == null ? "" : "${var.vm_ip}/${split("/", var.network_cidr)[1]}"
-  }
+  cloud_init_network_static = templatefile("./templates/cloud_init/cloud_init_network_static.tpl", {
+    network_interface = var.vm_network_interface,
+    network_gateway   = var.network_gateway,
+    vm_dns_list       = local.vm_dns_list,
+    vm_cidr           = var.vm_ip == null ? "" : "${var.vm_ip}/${split("/", var.network_cidr)[1]}",
+    extra_bridges     = var.extra_bridges})
+
+  cloud_init_network_dhcp = templatefile("./templates/cloud_init/cloud_init_network_dhcp.tpl", {
+    network_interface = var.vm_network_interface,
+    vm_dns_list       = local.vm_dns_list})
 }
 
 # Cloud-init configuration template #
@@ -44,7 +44,7 @@ resource "libvirt_cloudinit_disk" "cloud_init" {
   name           = "${var.vm_name}-cloud-init.iso"
   pool           = var.main_resource_pool_name
   user_data      = data.template_file.cloud_init_tpl.rendered
-  network_config = data.template_file.cloud_init_network_tpl.rendered
+  network_config = var.vm_ip != null ? local.cloud_init_network_static : local.cloud_init_network_dhcp
 }
 
 #================================
@@ -90,6 +90,14 @@ resource "libvirt_domain" "vm_domain" {
     addresses      = var.vm_ip != null ? [var.vm_ip] : null
     bridge         = var.network_bridge
     wait_for_lease = true
+  }
+
+  # Extra network bridges #
+  dynamic network_interface {
+    for_each = var.extra_bridges
+    content {
+      bridge = network_interface.value.bridge
+    }
   }
 
   # Storage configuration #

--- a/terraform/modules/vm/vm.tf
+++ b/terraform/modules/vm/vm.tf
@@ -20,7 +20,7 @@ locals {
     network_gateway   = var.network_gateway,
     vm_dns_list       = local.vm_dns_list,
     vm_cidr           = var.vm_ip == null ? "" : "${var.vm_ip}/${split("/", var.network_cidr)[1]}",
-    extra_bridges     = var.extra_bridges})
+    vm_extra_bridges     = var.vm_extra_bridges})
 
   cloud_init_network_dhcp = templatefile("./templates/cloud_init/cloud_init_network_dhcp.tpl", {
     network_interface = var.vm_network_interface,
@@ -94,7 +94,7 @@ resource "libvirt_domain" "vm_domain" {
 
   # Extra network bridges #
   dynamic network_interface {
-    for_each = var.extra_bridges
+    for_each = var.vm_extra_bridges
     content {
       bridge = network_interface.value.bridge
     }

--- a/terraform/templates/cloud_init/cloud_init_network_dhcp.tpl
+++ b/terraform/templates/cloud_init/cloud_init_network_dhcp.tpl
@@ -6,3 +6,7 @@ ethernets:
     dhcp6: false
     nameservers:
       addresses: [${vm_dns_list}]
+%{ for interface in vm_extra_bridges ~}
+  ${interface.networkInterface}:
+    addresses: [${interface.ipCidr}]
+%{ endfor ~}

--- a/terraform/templates/cloud_init/cloud_init_network_static.tpl
+++ b/terraform/templates/cloud_init/cloud_init_network_static.tpl
@@ -8,3 +8,7 @@ ethernets:
     gateway4: ${network_gateway}
     nameservers:
       addresses: [${vm_dns_list}]
+%{ for interface in extra_bridges ~}
+  ${interface.networkInterface}:
+    addresses: [${interface.ipCidr}]
+%{ endfor ~}

--- a/terraform/templates/cloud_init/cloud_init_network_static.tpl
+++ b/terraform/templates/cloud_init/cloud_init_network_static.tpl
@@ -8,7 +8,7 @@ ethernets:
     gateway4: ${network_gateway}
     nameservers:
       addresses: [${vm_dns_list}]
-%{ for interface in extra_bridges ~}
+%{ for interface in vm_extra_bridges ~}
   ${interface.networkInterface}:
     addresses: [${interface.ipCidr}]
 %{ endfor ~}


### PR DESCRIPTION
Implement https://github.com/MusicDin/kubitect/issues/34

Example config where:
**bridge** - name of the bridge on the host.
**networkInterface** - the name that the VM OS will assign the new network interface
**ipCidr** - the IP to assign the network interface in the VM (CIDR format)
```
cluster:
  nodes:
    worker:
      instances:
        - id: 1
          name: pipeline-1
          host: ubuntu-1
          ip: 192.168.20.210
          extraBridges:
            - bridge: br1
              networkInterface: ens4
              ipCidr: 192.168.21.210/24
            - bridge: br2
              networkInterface: ens5
              ipCidr: 192.168.22.210/24
```