### PR TITLE
Run terraform plan before apply

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -55,7 +55,7 @@ func init() {
 	rootCmd.AddCommand(applyCmd)
 
 	applyCmd.PersistentFlags().StringVarP(&env.ConfigPath, "config", "c", "", "specify path to the cluster config file")
-	applyCmd.PersistentFlags().StringVarP(&env.ClusterAction, "action", "a", env.DefaultClusterAction, "specify cluster action")
+	applyCmd.PersistentFlags().StringVarP(&env.ClusterAction, "action", "a", env.DefaultClusterAction, "specify cluster action [create, upgrade, scale]")
 	applyCmd.PersistentFlags().StringVar(&env.ClusterName, "cluster", env.DefaultClusterName, "specify the cluster to be used")
 	applyCmd.PersistentFlags().BoolVarP(&env.Local, "local", "l", false, "use a current directory as the cluster path")
 	applyCmd.PersistentFlags().BoolVar(&env.AutoApprove, "auto-approve", false, "automatically approve any user permission requests")

--- a/cli/helpers/terraform.go
+++ b/cli/helpers/terraform.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"cli/env"
+	"cli/utils"
 	"context"
 	"fmt"
 	"os"
@@ -25,6 +26,21 @@ func TerraformApply(clusterPath string) error {
 	tf, err := terraformInit(clusterPath)
 	if err != nil {
 		return err
+	}
+
+	// run a terraform plan first and get user confirmation to continue
+	changes, err := tf.Plan(context.Background())
+	if err != nil {
+		return fmt.Errorf("Error running Terraform apply: %w", err)
+	}
+
+	// Ask user for permission if there are any changes
+	if changes {
+		warning := "Proceed with terraform apply?"
+		confirm := utils.AskUserConfirmation(warning)
+		if !confirm {
+			return fmt.Errorf("User aborted.")
+		}
 	}
 
 	err = tf.Apply(context.Background())

--- a/cli/helpers/terraform.go
+++ b/cli/helpers/terraform.go
@@ -28,18 +28,20 @@ func TerraformApply(clusterPath string) error {
 		return err
 	}
 
-	// run a terraform plan first and get user confirmation to continue
-	changes, err := tf.Plan(context.Background())
-	if err != nil {
-		return fmt.Errorf("Error running Terraform apply: %w", err)
-	}
+	// run 'terraform plan' first to show changes
+	if !env.AutoApprove {
+		changes, err := tf.Plan(context.Background())
+		if err != nil {
+			return fmt.Errorf("Error running Terraform apply: %w", err)
+		}
 
-	// Ask user for permission if there are any changes
-	if changes {
-		warning := "Proceed with terraform apply?"
-		confirm := utils.AskUserConfirmation(warning)
-		if !confirm {
-			return fmt.Errorf("User aborted.")
+		// Ask user for permission if there are any changes
+		if changes {
+			warning := "Proceed with terraform apply?"
+			confirm := utils.AskUserConfirmation(warning)
+			if !confirm {
+				return fmt.Errorf("User aborted.")
+			}
 		}
 	}
 

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -230,6 +230,10 @@ kubernetes:
 
 ## Step 5 - Create the cluster
 
+!!! tip "Tip"
+
+    If you encounter any issues during the installation, please refer to the [troubleshooting](../other/troubleshooting) page first.
+
 Our final cluster configuration looks like this:
 
 ```yaml title="kubitect.yaml"
@@ -283,9 +287,12 @@ Also, let's name our cluster `my-first-cluster`.
 kubitect apply --cluster my-first-cluster --config kubitect.yaml
 ```
 
+When the configuration is applied, the Terraform plan shows the changes Terraform wants to make to your infrastructure.
+User confirmation of the plan is required before Kubitect begins creating the cluster.
+
 !!! tip "Tip"
 
-    If you encounter any issues during the installation, please refer to the [troubleshooting](../other/troubleshooting) page first.
+    To skip the user confirmation step, the flag `--auto-approve` can be used.
 
 When the cluster is applied, it is created in Kubitect's home directory, which has the following structure.
 ```


### PR DESCRIPTION
Implements https://github.com/MusicDin/kubitect/issues/27

I haven't added a specific flag for controlling this but it won't run if `auto-approve` is set.  In that case the plan would have been applied without prompting anyway.