### PR TITLE
Solved the issue with qemu-guest-agent

### DIFF
--- a/terraform/templates/cloud_init/cloud_init.tpl
+++ b/terraform/templates/cloud_init/cloud_init.tpl
@@ -17,4 +17,5 @@ packages:
   - qemu-guest-agent
 
 runcmd:
+  - [ systemctl, enable, qemu-guest-agent.service ]
   - [ systemctl, start, qemu-guest-agent.service ]


### PR DESCRIPTION
After restart, the qemu agent is not started because it's not enabled to start. As soon as it reboots due to an update the SO, the system fails and then no more agents. Especially because RunCMD only happens in the first boot.  In some race conditions in the apply, terraform also fails. 

So, IMO, the run cmd should enable and start to ensure it's going to be there when libvirt module for terraforms asks the IP to complete the installation. It works with an agent or DHCP but here is static most of the time.