### PR TITLE
Bump tf version and remove experimental features

### DIFF
--- a/cli/env/constatnts.go
+++ b/cli/env/constatnts.go
@@ -7,7 +7,7 @@ const (
 	ConstProjectClustersDir = "clusters"
 	ConstProjectUrl         = "https://github.com/MusicDin/kubitect"
 	ConstProjectVersion     = "v2.3.0"
-	ConstTerraformVersion   = "1.2.4"
+	ConstTerraformVersion   = "1.3.0"
 	ConstTerraformStatePath = "config/terraform/terraform.tfstate"
 	ConstKubeconfigPath     = "config/admin.conf"
 	ConstVenvBinDir         = "bin/venvs"

--- a/terraform/modules/host/main.tf
+++ b/terraform/modules/host/main.tf
@@ -32,10 +32,7 @@ resource "libvirt_pool" "data_resource_pools" {
 
   name = "${var.cluster_name}-${each.key}-data-resource-pool"
   type = "dir"
-  path = (each.value.path == null
-    ? pathexpand("/var/lib/libvirt/images/${var.cluster_name}-${each.key}-data-resource-pool")
-    : pathexpand("${trimsuffix(each.value.path, "/")}/${var.cluster_name}-${each.key}-data-resource-pool")
-  )
+  path = pathexpand("${trimsuffix(each.value.path, "/")}/${var.cluster_name}-${each.key}-data-resource-pool")
 }
 
 # Creates base OS image for nodes in a cluster #

--- a/terraform/modules/host/variables.tf
+++ b/terraform/modules/host/variables.tf
@@ -31,7 +31,7 @@ variable "hosts_mainResourcePoolPath" {
 variable "hosts_dataResourcePools" {
   type = list(object({
     name : string
-    path : optional(string)
+    path : optional(string, "/var/lib/libvirt/images/")
   }))
   description = "Additional data resource pools."
   default     = []

--- a/terraform/modules/host/versions.tf
+++ b/terraform/modules/host/versions.tf
@@ -1,6 +1,5 @@
 terraform {
-  experiments      = [module_variable_optional_attrs]
-  required_version = ">= 1.1.4"
+  required_version = ">= 1.3.0"
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"

--- a/terraform/modules/vm/variables.tf
+++ b/terraform/modules/vm/variables.tf
@@ -140,7 +140,7 @@ variable "vm_data_disks" {
   type = list(object({
     name : string
     size : number
-    pool : optional(string)
+    pool : optional(string, "main")
   }))
   description = "Additional data disks attached to the virtual machine"
 }

--- a/terraform/modules/vm/versions.tf
+++ b/terraform/modules/vm/versions.tf
@@ -1,6 +1,5 @@
 terraform {
-  experiments      = [module_variable_optional_attrs]
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"

--- a/terraform/modules/vm/vm.tf
+++ b/terraform/modules/vm/vm.tf
@@ -62,7 +62,7 @@ resource "libvirt_volume" "vm_data_disks" {
   for_each = { for disk in var.vm_data_disks : disk.name => disk }
 
   name = "${var.vm_name}-${each.key}-data-disk"
-  pool = (each.value.pool == null || each.value.pool == "main"
+  pool = (each.value.pool == "main"
     ? var.main_resource_pool_name
     : "${var.cluster_name}-${each.value.pool}-data-resource-pool"
   )

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,7 +1,5 @@
 terraform {
-
-  experiments      = [module_variable_optional_attrs]
-  required_version = ">= 1.1.4"
+  required_version = ">= 1.3.0"
 
   backend "local" {
     path = "../config/terraform/terraform.tfstate"


### PR DESCRIPTION
This pull requests bumps required Terraform version to `1.3.0` and removes experimental feature `module_variable_optional_attrs`.
As a result, the corresponding warnings are removed when the cluster configuration is applied.