### PR TITLE
Rename cli package to make a valid import path

### DIFF
--- a/cli/app/context.go
+++ b/cli/app/context.go
@@ -1,13 +1,14 @@
 package app
 
 import (
-	"cli/env"
-	"cli/ui"
 	"fmt"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
+
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/ui"
 )
 
 const (

--- a/cli/app/context_mock.go
+++ b/cli/app/context_mock.go
@@ -1,9 +1,10 @@
 package app
 
 import (
-	"cli/ui"
 	"path"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/ui"
 )
 
 type (

--- a/cli/app/context_test.go
+++ b/cli/app/context_test.go
@@ -1,10 +1,11 @@
 package app
 
 import (
-	"cli/env"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/env"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/cluster/action_apply.go
+++ b/cli/cluster/action_apply.go
@@ -1,17 +1,18 @@
 package cluster
 
 import (
-	"cli/cluster/event"
-	"cli/env"
-	"cli/tools/git"
-	"cli/ui"
-	"cli/utils/cmp"
-	"cli/utils/file"
-	"cli/utils/keygen"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
+
+	"github.com/MusicDin/kubitect/cli/cluster/event"
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/tools/git"
+	"github.com/MusicDin/kubitect/cli/ui"
+	"github.com/MusicDin/kubitect/cli/utils/cmp"
+	"github.com/MusicDin/kubitect/cli/utils/file"
+	"github.com/MusicDin/kubitect/cli/utils/keygen"
 )
 
 type ApplyAction string

--- a/cli/cluster/action_apply_test.go
+++ b/cli/cluster/action_apply_test.go
@@ -1,14 +1,15 @@
 package cluster
 
 import (
-	"cli/config/modelconfig"
-	"cli/env"
-	"cli/tools/git"
 	"fmt"
 	"os"
 	"path"
 	"testing"
 	"time"
+
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/tools/git"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/cluster/action_destroy.go
+++ b/cli/cluster/action_destroy.go
@@ -1,9 +1,10 @@
 package cluster
 
 import (
-	"cli/ui"
 	"fmt"
 	"os"
+
+	"github.com/MusicDin/kubitect/cli/ui"
 )
 
 // Destroy destroys an active cluster. If cluster does not exist

--- a/cli/cluster/cluster.go
+++ b/cli/cluster/cluster.go
@@ -1,23 +1,25 @@
 package cluster
 
 import (
-	"cli/app"
-	"cli/cluster/executors"
-	"cli/cluster/executors/kubespray"
-	"cli/cluster/provisioner"
-	"cli/cluster/provisioner/terraform"
-	"cli/config/modelconfig"
-	"cli/config/modelinfra"
-	"cli/env"
-	"cli/tools/virtualenv"
-	"cli/ui"
-	"cli/utils/defaults"
-	"cli/utils/file"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/MusicDin/kubitect/cli/utils/file"
+
+	"github.com/MusicDin/kubitect/cli/app"
+	"github.com/MusicDin/kubitect/cli/cluster/executors"
+	"github.com/MusicDin/kubitect/cli/cluster/executors/kubespray"
+	"github.com/MusicDin/kubitect/cli/cluster/provisioner"
+	"github.com/MusicDin/kubitect/cli/cluster/provisioner/terraform"
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	"github.com/MusicDin/kubitect/cli/config/modelinfra"
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/tools/virtualenv"
+	"github.com/MusicDin/kubitect/cli/ui"
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 )
 
 type Cluster struct {

--- a/cli/cluster/cluster_mock.go
+++ b/cli/cluster/cluster_mock.go
@@ -1,16 +1,17 @@
 package cluster
 
 import (
-	"cli/app"
-	"cli/cluster/executors"
-	"cli/cluster/provisioner"
-	"cli/config/modelconfig"
-	"cli/ui"
-	"cli/utils/template"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/app"
+	"github.com/MusicDin/kubitect/cli/cluster/executors"
+	"github.com/MusicDin/kubitect/cli/cluster/provisioner"
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	"github.com/MusicDin/kubitect/cli/ui"
+	"github.com/MusicDin/kubitect/cli/utils/template"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/cluster/cluster_test.go
+++ b/cli/cluster/cluster_test.go
@@ -1,12 +1,13 @@
 package cluster
 
 import (
-	"cli/app"
-	"cli/utils/template"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/app"
+	"github.com/MusicDin/kubitect/cli/utils/template"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/cluster/errors.go
+++ b/cli/cluster/errors.go
@@ -1,6 +1,6 @@
 package cluster
 
-import "cli/ui"
+import "github.com/MusicDin/kubitect/cli/ui"
 
 func NewInvalidClusterDirError(missingFiles []string) error {
 	return ui.NewErrorBlock(ui.ERROR,

--- a/cli/cluster/event/errors.go
+++ b/cli/cluster/event/errors.go
@@ -1,7 +1,7 @@
 package event
 
 import (
-	"cli/ui"
+	"github.com/MusicDin/kubitect/cli/ui"
 )
 
 func NewConfigChangeError(msg string, paths ...string) error {

--- a/cli/cluster/event/events.go
+++ b/cli/cluster/event/events.go
@@ -1,7 +1,7 @@
 package event
 
 import (
-	"cli/utils/cmp"
+	"github.com/MusicDin/kubitect/cli/utils/cmp"
 )
 
 type EventType string

--- a/cli/cluster/event/events_list.go
+++ b/cli/cluster/event/events_list.go
@@ -1,6 +1,6 @@
 package event
 
-import "cli/utils/cmp"
+import "github.com/MusicDin/kubitect/cli/utils/cmp"
 
 var UpgradeEvents = Events{
 	{

--- a/cli/cluster/event/events_mock.go
+++ b/cli/cluster/event/events_mock.go
@@ -1,8 +1,9 @@
 package event
 
 import (
-	"cli/utils/cmp"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/utils/cmp"
 )
 
 func MockEvent(t *testing.T, eventType EventType, changes []cmp.Change) Event {

--- a/cli/cluster/event/events_test.go
+++ b/cli/cluster/event/events_test.go
@@ -1,12 +1,13 @@
 package event
 
 import (
-	"cli/config/modelconfig"
-	"cli/utils/cmp"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	"github.com/MusicDin/kubitect/cli/utils/cmp"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/cluster/executors/executor.go
+++ b/cli/cluster/executors/executor.go
@@ -1,6 +1,6 @@
 package executors
 
-import "cli/cluster/event"
+import "github.com/MusicDin/kubitect/cli/cluster/event"
 
 type Executor interface {
 	Init() error

--- a/cli/cluster/executors/executor_mock.go
+++ b/cli/cluster/executors/executor_mock.go
@@ -1,8 +1,9 @@
 package executors
 
 import (
-	"cli/cluster/event"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/cluster/event"
 )
 
 type executorMock struct{}

--- a/cli/cluster/executors/kubespray/kubespray.go
+++ b/cli/cluster/executors/kubespray/kubespray.go
@@ -1,18 +1,19 @@
 package kubespray
 
 import (
-	"cli/cluster/event"
-	"cli/cluster/executors"
-	"cli/config/modelconfig"
-	"cli/config/modelinfra"
-	"cli/env"
-	"cli/tools/ansible"
-	"cli/tools/git"
-	"cli/tools/virtualenv"
-	"cli/ui"
 	"fmt"
 	"os"
 	"path"
+
+	"github.com/MusicDin/kubitect/cli/cluster/event"
+	"github.com/MusicDin/kubitect/cli/cluster/executors"
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	"github.com/MusicDin/kubitect/cli/config/modelinfra"
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/tools/ansible"
+	"github.com/MusicDin/kubitect/cli/tools/git"
+	"github.com/MusicDin/kubitect/cli/tools/virtualenv"
+	"github.com/MusicDin/kubitect/cli/ui"
 )
 
 type kubespray struct {

--- a/cli/cluster/executors/kubespray/kubespray_test.go
+++ b/cli/cluster/executors/kubespray/kubespray_test.go
@@ -1,17 +1,18 @@
 package kubespray
 
 import (
-	"cli/cluster/event"
-	"cli/cluster/executors"
-	"cli/config/modelconfig"
-	"cli/config/modelinfra"
-	"cli/env"
-	"cli/tools/ansible"
-	"cli/utils/cmp"
 	"fmt"
 	"path"
 	"reflect"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/cluster/event"
+	"github.com/MusicDin/kubitect/cli/cluster/executors"
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	"github.com/MusicDin/kubitect/cli/config/modelinfra"
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/tools/ansible"
+	"github.com/MusicDin/kubitect/cli/utils/cmp"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/cluster/executors/kubespray/playbooks.go
+++ b/cli/cluster/executors/kubespray/playbooks.go
@@ -1,9 +1,10 @@
 package kubespray
 
 import (
-	"cli/tools/ansible"
 	"path/filepath"
 	"strings"
+
+	"github.com/MusicDin/kubitect/cli/tools/ansible"
 )
 
 type PlaybookTag string

--- a/cli/cluster/executors/kubespray/template.go
+++ b/cli/cluster/executors/kubespray/template.go
@@ -1,9 +1,10 @@
 package kubespray
 
 import (
-	"cli/config/modelconfig"
-	"cli/utils/template"
 	"path"
+
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	"github.com/MusicDin/kubitect/cli/utils/template"
 )
 
 const groupVarsDir = "group_vars"

--- a/cli/cluster/executors/kubespray/template_test.go
+++ b/cli/cluster/executors/kubespray/template_test.go
@@ -1,9 +1,10 @@
 package kubespray
 
 import (
-	"cli/config/modelconfig"
-	"cli/utils/template"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	"github.com/MusicDin/kubitect/cli/utils/template"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/cluster/meta.go
+++ b/cli/cluster/meta.go
@@ -1,12 +1,13 @@
 package cluster
 
 import (
-	"cli/app"
-	"cli/cluster/executors"
-	"cli/cluster/provisioner"
-	"cli/cluster/provisioner/terraform"
-	"cli/utils/file"
 	"path/filepath"
+
+	"github.com/MusicDin/kubitect/cli/app"
+	"github.com/MusicDin/kubitect/cli/cluster/executors"
+	"github.com/MusicDin/kubitect/cli/cluster/provisioner"
+	"github.com/MusicDin/kubitect/cli/cluster/provisioner/terraform"
+	"github.com/MusicDin/kubitect/cli/utils/file"
 )
 
 const (

--- a/cli/cluster/provisioner/terraform/template.go
+++ b/cli/cluster/provisioner/terraform/template.go
@@ -1,12 +1,13 @@
 package terraform
 
 import (
-	"cli/config/modelconfig"
-	"cli/utils/template"
 	"fmt"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	"github.com/MusicDin/kubitect/cli/utils/template"
 )
 
 type MainTemplate struct {

--- a/cli/cluster/provisioner/terraform/template_test.go
+++ b/cli/cluster/provisioner/terraform/template_test.go
@@ -1,11 +1,12 @@
 package terraform
 
 import (
-	"cli/config/modelconfig"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/cluster/provisioner/terraform/terraform.go
+++ b/cli/cluster/provisioner/terraform/terraform.go
@@ -1,17 +1,18 @@
 package terraform
 
 import (
-	"cli/cluster/provisioner"
-	"cli/config/modelconfig"
-	"cli/env"
-	"cli/ui"
-	"cli/utils/file"
 	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path"
 	"syscall"
+
+	"github.com/MusicDin/kubitect/cli/cluster/provisioner"
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/ui"
+	"github.com/MusicDin/kubitect/cli/utils/file"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hc-install/fs"

--- a/cli/cluster/provisioner/terraform/terraform_test.go
+++ b/cli/cluster/provisioner/terraform/terraform_test.go
@@ -1,13 +1,14 @@
 package terraform
 
 import (
-	"cli/config/modelconfig"
-	"cli/env"
-	"cli/ui"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/ui"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/cluster/utils.go
+++ b/cli/cluster/utils.go
@@ -1,9 +1,10 @@
 package cluster
 
 import (
-	"cli/utils/file"
-	"cli/utils/validation"
 	"fmt"
+
+	"github.com/MusicDin/kubitect/cli/utils/file"
+	"github.com/MusicDin/kubitect/cli/utils/validation"
 )
 
 // readConfig reads configuration file on the given path and converts it into

--- a/cli/cluster/utils_test.go
+++ b/cli/cluster/utils_test.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"testing"
 
-	v "cli/utils/validation"
+	v "github.com/MusicDin/kubitect/cli/utils/validation"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"cli/env"
+	"github.com/MusicDin/kubitect/cli/env"
 
 	"github.com/spf13/cobra"
 )

--- a/cli/cmd/cmd_apply.go
+++ b/cli/cmd/cmd_apply.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"cli/app"
-	"cli/cluster"
-	"cli/env"
+	"github.com/MusicDin/kubitect/cli/app"
+	"github.com/MusicDin/kubitect/cli/cluster"
+	"github.com/MusicDin/kubitect/cli/env"
 
 	"github.com/spf13/cobra"
 )

--- a/cli/cmd/cmd_destroy.go
+++ b/cli/cmd/cmd_destroy.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"cli/app"
 	"fmt"
+
+	"github.com/MusicDin/kubitect/cli/app"
 
 	"github.com/spf13/cobra"
 )

--- a/cli/cmd/cmd_export_config.go
+++ b/cli/cmd/cmd_export_config.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"cli/app"
-	"cli/utils/file"
 	"fmt"
 	"os"
+
+	"github.com/MusicDin/kubitect/cli/app"
+	"github.com/MusicDin/kubitect/cli/utils/file"
 
 	"github.com/spf13/cobra"
 )

--- a/cli/cmd/cmd_export_kubeconfig.go
+++ b/cli/cmd/cmd_export_kubeconfig.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"cli/app"
-	"cli/utils/file"
 	"fmt"
 	"os"
+
+	"github.com/MusicDin/kubitect/cli/app"
+	"github.com/MusicDin/kubitect/cli/utils/file"
 
 	"github.com/spf13/cobra"
 )

--- a/cli/cmd/cmd_list.go
+++ b/cli/cmd/cmd_list.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
-	"cli/app"
-	"cli/ui"
 	"strings"
+
+	"github.com/MusicDin/kubitect/cli/app"
+
+	"github.com/MusicDin/kubitect/cli/ui"
 
 	"github.com/spf13/cobra"
 )

--- a/cli/cmd/cmd_purge.go
+++ b/cli/cmd/cmd_purge.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"cli/app"
-	"cli/ui"
-	"cli/utils/file"
 	"fmt"
+
+	"github.com/MusicDin/kubitect/cli/app"
+	"github.com/MusicDin/kubitect/cli/ui"
+	"github.com/MusicDin/kubitect/cli/utils/file"
 
 	"github.com/spf13/cobra"
 )

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"cli/app"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/app"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"

--- a/cli/cmd/meta_clusters.go
+++ b/cli/cmd/meta_clusters.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
-	"cli/app"
-	"cli/cluster"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+
+	"github.com/MusicDin/kubitect/cli/app"
+	"github.com/MusicDin/kubitect/cli/cluster"
 )
 
 type MetaClusters []cluster.ClusterMeta

--- a/cli/cmd/meta_clusters_test.go
+++ b/cli/cmd/meta_clusters_test.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
-	"cli/app"
-	"cli/cluster"
 	"os"
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/app"
+	"github.com/MusicDin/kubitect/cli/cluster"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/addons.go
+++ b/cli/config/modelconfig/addons.go
@@ -1,6 +1,6 @@
 package modelconfig
 
-import v "cli/utils/validation"
+import v "github.com/MusicDin/kubitect/cli/utils/validation"
 
 type Addons struct {
 	Kubespray string `yaml:"kubespray,omitempty" opt:"-"`

--- a/cli/config/modelconfig/cluster.go
+++ b/cli/config/modelconfig/cluster.go
@@ -1,6 +1,6 @@
 package modelconfig
 
-import v "cli/utils/validation"
+import v "github.com/MusicDin/kubitect/cli/utils/validation"
 
 type Cluster struct {
 	Name         string       `yaml:"name"`

--- a/cli/config/modelconfig/cluster_network.go
+++ b/cli/config/modelconfig/cluster_network.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
-	v "cli/utils/validation"
+	v "github.com/MusicDin/kubitect/cli/utils/validation"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 )
 
 type NetworkMode string

--- a/cli/config/modelconfig/cluster_network_test.go
+++ b/cli/config/modelconfig/cluster_network_test.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/cluster_node_template.go
+++ b/cli/config/modelconfig/cluster_node_template.go
@@ -1,9 +1,9 @@
 package modelconfig
 
 import (
-	"cli/env"
-	"cli/utils/defaults"
-	v "cli/utils/validation"
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
+	v "github.com/MusicDin/kubitect/cli/utils/validation"
 )
 
 type NodeTemplate struct {

--- a/cli/config/modelconfig/cluster_node_template_test.go
+++ b/cli/config/modelconfig/cluster_node_template_test.go
@@ -1,9 +1,10 @@
 package modelconfig
 
 import (
-	"cli/env"
-	"cli/utils/defaults"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/cluster_nodes.go
+++ b/cli/config/modelconfig/cluster_nodes.go
@@ -1,6 +1,6 @@
 package modelconfig
 
-import v "cli/utils/validation"
+import v "github.com/MusicDin/kubitect/cli/utils/validation"
 
 const (
 	defaultVCpu         = VCpu(2)

--- a/cli/config/modelconfig/cluster_nodes_lb.go
+++ b/cli/config/modelconfig/cluster_nodes_lb.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
-	v "cli/utils/validation"
+	v "github.com/MusicDin/kubitect/cli/utils/validation"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 )
 
 var (

--- a/cli/config/modelconfig/cluster_nodes_lb_test.go
+++ b/cli/config/modelconfig/cluster_nodes_lb_test.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/cluster_nodes_master.go
+++ b/cli/config/modelconfig/cluster_nodes_master.go
@@ -1,8 +1,8 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
-	v "cli/utils/validation"
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
+	v "github.com/MusicDin/kubitect/cli/utils/validation"
 )
 
 type MasterDefault struct {

--- a/cli/config/modelconfig/cluster_nodes_master_test.go
+++ b/cli/config/modelconfig/cluster_nodes_master_test.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/cluster_nodes_test.go
+++ b/cli/config/modelconfig/cluster_nodes_test.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/cluster_nodes_worker.go
+++ b/cli/config/modelconfig/cluster_nodes_worker.go
@@ -1,8 +1,8 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
-	v "cli/utils/validation"
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
+	v "github.com/MusicDin/kubitect/cli/utils/validation"
 )
 
 type WorkerDefault struct {

--- a/cli/config/modelconfig/cluster_nodes_worker_test.go
+++ b/cli/config/modelconfig/cluster_nodes_worker_test.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/cluster_test.go
+++ b/cli/config/modelconfig/cluster_test.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/common.go
+++ b/cli/config/modelconfig/common.go
@@ -1,6 +1,6 @@
 package modelconfig
 
-import v "cli/utils/validation"
+import v "github.com/MusicDin/kubitect/cli/utils/validation"
 
 // Uint8 is intentionally set to int to avoid panic if value is set
 // outside the uint8 size.

--- a/cli/config/modelconfig/config.go
+++ b/cli/config/modelconfig/config.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	v "cli/utils/validation"
 	"strings"
+
+	v "github.com/MusicDin/kubitect/cli/utils/validation"
 )
 
 // Keys of custom validators

--- a/cli/config/modelconfig/config_test.go
+++ b/cli/config/modelconfig/config_test.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/host.go
+++ b/cli/config/modelconfig/host.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
-	v "cli/utils/validation"
+	v "github.com/MusicDin/kubitect/cli/utils/validation"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 )
 
 const (

--- a/cli/config/modelconfig/host_conn.go
+++ b/cli/config/modelconfig/host_conn.go
@@ -1,9 +1,11 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
-	v "cli/utils/validation"
 	"fmt"
+
+	v "github.com/MusicDin/kubitect/cli/utils/validation"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 )
 
 type Connection struct {

--- a/cli/config/modelconfig/host_conn_test.go
+++ b/cli/config/modelconfig/host_conn_test.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/host_test.go
+++ b/cli/config/modelconfig/host_test.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/kubernetes.go
+++ b/cli/config/modelconfig/kubernetes.go
@@ -1,11 +1,12 @@
 package modelconfig
 
 import (
-	"cli/env"
-	v "cli/utils/validation"
 	"fmt"
 
-	"cli/utils/defaults"
+	"github.com/MusicDin/kubitect/cli/env"
+	v "github.com/MusicDin/kubitect/cli/utils/validation"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 )
 
 type Kubernetes struct {

--- a/cli/config/modelconfig/kubernetes_test.go
+++ b/cli/config/modelconfig/kubernetes_test.go
@@ -3,8 +3,8 @@ package modelconfig
 import (
 	"testing"
 
-	"cli/env"
-	"cli/utils/defaults"
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/kubitect.go
+++ b/cli/config/modelconfig/kubitect.go
@@ -1,6 +1,6 @@
 package modelconfig
 
-import v "cli/utils/validation"
+import v "github.com/MusicDin/kubitect/cli/utils/validation"
 
 type Kubitect struct {
 	Url     URL           `yaml:"url,omitempty"`

--- a/cli/config/modelconfig/kubitect_test.go
+++ b/cli/config/modelconfig/kubitect_test.go
@@ -1,8 +1,9 @@
 package modelconfig
 
 import (
-	"cli/env"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/env"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelconfig/mock.go
+++ b/cli/config/modelconfig/mock.go
@@ -1,10 +1,11 @@
 package modelconfig
 
 import (
-	"cli/utils/defaults"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/config/modelinfra/config.go
+++ b/cli/config/modelinfra/config.go
@@ -1,8 +1,8 @@
 package modelinfra
 
 import (
-	"cli/config/modelconfig"
-	v "cli/utils/validation"
+	"github.com/MusicDin/kubitect/cli/config/modelconfig"
+	v "github.com/MusicDin/kubitect/cli/utils/validation"
 )
 
 type Config struct {

--- a/cli/config/modelinfra/config_test.go
+++ b/cli/config/modelinfra/config_test.go
@@ -1,8 +1,9 @@
 package modelinfra
 
 import (
-	c "cli/config/modelconfig"
 	"testing"
+
+	c "github.com/MusicDin/kubitect/cli/config/modelconfig"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,4 +1,4 @@
-module cli
+module github.com/MusicDin/kubitect/cli
 
 go 1.18
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"cli/cmd"
-	"cli/ui"
 	"os"
+
+	"github.com/MusicDin/kubitect/cli/cmd"
+	"github.com/MusicDin/kubitect/cli/ui"
 )
 
 func main() {

--- a/cli/tools/ansible/ansible.go
+++ b/cli/tools/ansible/ansible.go
@@ -1,13 +1,13 @@
 package ansible
 
 import (
-	"cli/ui"
 	"context"
 	"fmt"
 	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/MusicDin/kubitect/cli/ui"
 	"github.com/apenella/go-ansible/pkg/execute"
 	"github.com/apenella/go-ansible/pkg/options"
 	"github.com/apenella/go-ansible/pkg/playbook"

--- a/cli/tools/ansible/ansible_test.go
+++ b/cli/tools/ansible/ansible_test.go
@@ -1,9 +1,9 @@
 package ansible
 
 import (
-	"cli/ui"
 	"testing"
 
+	"github.com/MusicDin/kubitect/cli/ui"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cli/tools/git/git.go
+++ b/cli/tools/git/git.go
@@ -1,11 +1,11 @@
 package git
 
 import (
-	"cli/ui"
 	"fmt"
 	"os"
 	"regexp"
 
+	"github.com/MusicDin/kubitect/cli/ui"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 )

--- a/cli/tools/git/git_test.go
+++ b/cli/tools/git/git_test.go
@@ -1,10 +1,10 @@
 package git
 
 import (
-	"cli/env"
-	"cli/ui"
 	"testing"
 
+	"github.com/MusicDin/kubitect/cli/env"
+	"github.com/MusicDin/kubitect/cli/ui"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cli/tools/virtualenv/virtualenv.go
+++ b/cli/tools/virtualenv/virtualenv.go
@@ -1,10 +1,11 @@
 package virtualenv
 
 import (
-	"cli/ui"
 	"fmt"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/MusicDin/kubitect/cli/ui"
 )
 
 type (

--- a/cli/tools/virtualenv/virtualenv_test.go
+++ b/cli/tools/virtualenv/virtualenv_test.go
@@ -1,12 +1,12 @@
 package virtualenv
 
 import (
-	"cli/ui"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 
+	"github.com/MusicDin/kubitect/cli/ui"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cli/ui/block.go
+++ b/cli/ui/block.go
@@ -1,9 +1,10 @@
 package ui
 
 import (
-	"cli/ui/streams"
 	"fmt"
 	"strings"
+
+	"github.com/MusicDin/kubitect/cli/ui/streams"
 )
 
 // Block symbols

--- a/cli/ui/fmt.go
+++ b/cli/ui/fmt.go
@@ -1,8 +1,9 @@
 package ui
 
 import (
-	"cli/ui/streams"
 	"strings"
+
+	"github.com/MusicDin/kubitect/cli/ui/streams"
 )
 
 // format formats given string into multiple lines that fit the

--- a/cli/ui/fmt_test.go
+++ b/cli/ui/fmt_test.go
@@ -1,9 +1,10 @@
 package ui
 
 import (
-	"cli/ui/streams"
 	"strings"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/ui/streams"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/ui/ui.go
+++ b/cli/ui/ui.go
@@ -1,10 +1,11 @@
 package ui
 
 import (
-	"cli/ui/streams"
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/MusicDin/kubitect/cli/ui/streams"
 )
 
 // Global Ui singleton

--- a/cli/ui/ui_mock.go
+++ b/cli/ui/ui_mock.go
@@ -1,9 +1,10 @@
 package ui
 
 import (
-	"cli/ui/streams"
 	"os"
 	"testing"
+
+	"github.com/MusicDin/kubitect/cli/ui/streams"
 
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
Renamed `cli` to `github.com/MusicDin/kubitect/cli` so that https://pkg.go.dev/github.com/MusicDin/kubitect/cli can be registered correctly.