### PR TITLE
Remove Kubespray subsection from cluster config

### DIFF
--- a/cli/cluster/event/events_list.go
+++ b/cli/cluster/event/events_list.go
@@ -7,10 +7,6 @@ var UpgradeEvents = Events{
 		eType: OK,
 		path:  "Kubernetes.Version",
 	},
-	{
-		eType: OK,
-		path:  "Kubernetes.Kubespray.Version",
-	},
 }
 
 var ScaleEvents = Events{
@@ -187,11 +183,8 @@ var ModifyEvents = Events{
 	// Prevent k8s properties changes
 	{
 		eType: BLOCK,
-		paths: []string{
-			"Kubernetes.Version",
-			"Kubernetes.Kubespray.Version",
-		},
-		msg: "Changing Kubernetes or Kubespray version is allowed only when upgrading the cluster.\nTo upgrade the cluster run apply command with '--action upgrade' flag.",
+		path:  "Kubernetes.Version",
+		msg:   "Changing Kubernetes is allowed only when upgrading the cluster.\nTo upgrade the cluster run apply command with '--action upgrade' flag.",
 	},
 	// Allow addons changes
 	{

--- a/cli/config/modelconfig/kubernetes.go
+++ b/cli/config/modelconfig/kubernetes.go
@@ -13,7 +13,6 @@ type Kubernetes struct {
 	Version       KubernetesVersion `yaml:"version"`
 	DnsMode       DnsMode           `yaml:"dnsMode"`
 	NetworkPlugin NetworkPlugin     `yaml:"networkPlugin"`
-	Kubespray     Kubespray         `yaml:"kubespray,omitempty"`
 	Other         Other             `yaml:"other"`
 }
 
@@ -22,7 +21,6 @@ func (k Kubernetes) Validate() error {
 		v.Field(&k.Version, v.NotEmpty()),
 		v.Field(&k.DnsMode, v.NotEmpty()),
 		v.Field(&k.NetworkPlugin, v.NotEmpty()),
-		v.Field(&k.Kubespray, v.NotEmpty()),
 		v.Field(&k.Other),
 	)
 }
@@ -78,16 +76,4 @@ func (p NetworkPlugin) Validate() error {
 type Other struct {
 	AutoRenewCertificates bool `yaml:"autoRenewCertificates"`
 	CopyKubeconfig        bool `yaml:"copyKubeconfig"`
-}
-
-type Kubespray struct {
-	URL     URL           `yaml:"url,omitempty"`
-	Version MasterVersion `yaml:"version,omitempty"`
-}
-
-func (k Kubespray) Validate() error {
-	return v.Struct(&k,
-		v.Field(&k.URL, v.OmitEmpty()),
-		v.Field(&k.Version),
-	)
 }

--- a/cli/config/modelconfig/kubernetes_test.go
+++ b/cli/config/modelconfig/kubernetes_test.go
@@ -36,27 +36,12 @@ func TestNetworkPlugin(t *testing.T) {
 	assert.NoError(t, CILIUM.Validate())
 }
 
-func TestKubespray(t *testing.T) {
-	ks1 := Kubespray{
-		Version: MasterVersion("master"),
-	}
-
-	ks2 := Kubespray{
-		Version: MasterVersion("master"),
-		URL:     URL(env.ConstKubesprayUrl),
-	}
-
-	assert.ErrorContains(t, Kubespray{}.Validate(), "Field 'version' must be a valid semantic version prefixed with 'v'")
-	assert.NoError(t, ks1.Validate())
-	assert.NoError(t, ks2.Validate())
-}
-
 func TestKubernetes_Empty(t *testing.T) {
 	k8s := Kubernetes{}
 	assert.ErrorContains(t, k8s.Validate(), "Field 'version' is required and cannot be empty.")
 	assert.ErrorContains(t, k8s.Validate(), "Field 'dnsMode' is required and cannot be empty.")
 	assert.ErrorContains(t, k8s.Validate(), "Field 'networkPlugin' is required and cannot be empty.")
-	assert.ErrorContains(t, defaults.Assign(&k8s).Validate(), "Field 'kubespray' is required and cannot be empty.")
+	assert.NoError(t, defaults.Assign(&k8s).Validate())
 }
 
 func TestKubernetes_Valid(t *testing.T) {
@@ -64,9 +49,6 @@ func TestKubernetes_Valid(t *testing.T) {
 		Version:       env.ConstKubernetesVersion,
 		DnsMode:       COREDNS,
 		NetworkPlugin: CALICO,
-		Kubespray: Kubespray{
-			Version: "v1.2.3",
-		},
 		Other: Other{
 			AutoRenewCertificates: true,
 			CopyKubeconfig:        true,

--- a/cli/config/modelconfig/mock.go
+++ b/cli/config/modelconfig/mock.go
@@ -120,9 +120,6 @@ func MockConfig(t *testing.T) Config {
 		},
 		Kubernetes: Kubernetes{
 			Version: "v1.24.7",
-			Kubespray: Kubespray{
-				Version: "v2.21.0",
-			},
 		},
 	}
 

--- a/docs/examples/full-example.md
+++ b/docs/examples/full-example.md
@@ -171,12 +171,9 @@ cluster:
 # Kubespray to use and which network plugin and DNS server to install.
 #
 kubernetes:
-  version: v1.23.7
+  version: v1.24.7
   networkPlugin: calico
   dnsMode: coredns
-  kubespray:
-    url: "https://github.com/kubernetes-sigs/kubespray.git"
-    version: v2.20.0
   other:
     copyKubeconfig: false
 

--- a/docs/examples/ha-cluster.md
+++ b/docs/examples/ha-cluster.md
@@ -305,9 +305,7 @@ cluster:
                   size: 512
 
     kubernetes:
-      version: v1.23.7
-      kubespray:
-        version: v2.20.0
+      version: v1.24.7
     ```
 
 ## Step 5: Applying the configuration

--- a/docs/examples/multi-master-cluster.md
+++ b/docs/examples/multi-master-cluster.md
@@ -112,11 +112,9 @@ By default, the load balancer is configured to distribute traffic received on po
               ip: 192.168.113.22
 
     kubernetes:
-      version: v1.23.7
+      version: v1.24.7
       networkPlugin: calico
       dnsMode: coredns
-      kubespray:
-        version: v2.20.0
     ```
 
 ## Step 2: Applying the configuration

--- a/docs/examples/multi-worker-cluster.md
+++ b/docs/examples/multi-worker-cluster.md
@@ -77,11 +77,9 @@ cluster:
             - id: 99
 
     kubernetes:
-      version: v1.23.7
+      version: v1.24.7
       networkPlugin: calico
       dnsMode: coredns
-      kubespray:
-        version: v2.20.0
     ```
 
 ## Step 2: Applying the configuration

--- a/docs/examples/rook-cluster.md
+++ b/docs/examples/rook-cluster.md
@@ -132,9 +132,7 @@ This behavior can be restricted with node selectors.
                   size: 32
 
     kubernetes:
-      version: v1.23.7
-      kubespray:
-        version: v2.20.0
+      version: v1.24.7
 
     addons:
       rook:
@@ -278,9 +276,7 @@ addons:
                   size: 32
 
     kubernetes:
-      version: v1.23.7
-      kubespray:
-        version: v2.20.0
+      version: v1.24.7
 
     addons:
       rook:

--- a/docs/examples/single-node-cluster.md
+++ b/docs/examples/single-node-cluster.md
@@ -67,11 +67,9 @@ cluster:
               ip: 192.168.113.10
 
     kubernetes:
-      version: v1.23.7
+      version: v1.24.7
       networkPlugin: calico
       dnsMode: coredns
-      kubespray:
-        version: v2.20.0
     ```
 
 ## Step 2: Applying the configuration

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -217,19 +217,15 @@ cluster:
 
 ### Step 4.4 - Kubernetes properties
 
-The last part of the cluster configuration consists of the Kubernetes properties.
-In this section we define the Kubernetes version, the DNS plugin and so on.
-It is also important to check if Kubespray supports a specific Kubernetes version.
+The last section of the cluster configuration is contains the Kubernetes properties, 
+such as the version, network plugin, and DNS mode.
 
-If you are using a custom Kubespray, you can also specify the URL to a custom Git repository.
 
 ```yaml title="kubitect.yaml"
 kubernetes:
-  version: v1.23.7
+  version: v1.24.7
   networkPlugin: calico
   dnsMode: coredns
-  kubespray:
-    version: v2.20.0
 ```
 
 ## Step 5 - Create the cluster
@@ -278,11 +274,9 @@ cluster:
           ram: 4
 
 kubernetes:
-  version: v1.23.7
+  version: v1.24.7
   networkPlugin: calico
   dnsMode: coredns
-  kubespray:
-    version: v2.20.0
 ```
 
 Now create the cluster by applying your custom configuration using the Kubitect command line tool. 

--- a/docs/theme/overrides/introduction.html
+++ b/docs/theme/overrides/introduction.html
@@ -70,8 +70,7 @@
                 <div class="card-header">Reliable, scalable and reproducible</div class="card-header">
                 <p class="card-content-text text-center">
                     By using a single configuration file, Kubitect clusters can be easily replicated in different
-                    environments,
-                    while Kubespray ensures reliability and scalability.
+                    environments, while Kubespray ensures reliability and scalability.
                 </p>
 
                 <div class="card-footer-nav text-center">

--- a/docs/user-guide/configuration/kubernetes.md
+++ b/docs/user-guide/configuration/kubernetes.md
@@ -7,55 +7,21 @@
 
 <div markdown="1" class="text-justify">
 
-The Kubernetes section of the configuration file contains properties that are closely related to Kubernetes, such as Kubernetes version, network plugin, and DNS mode. 
-In addition, the Kubespray project version and URL can also be specified in this section of the Kubitect configuration.
+The Kubernetes section of the configuration file contains properties that are closely related to Kubernetes, such as Kubernetes version, network plugin, and DNS mode.
 
 ## Configuration
-
-### Kubespray version
-
-:material-tag-arrow-up-outline: [v2.0.0][tag 2.0.0]
-&ensp;
-:material-alert-circle-outline: Required
-
-As Kubitect relays on the Kubespray for deploying a Kubernetes cluster, a Kubespray project is cloned during a cluster creation.
-This property defines the version of the Kubespray to be cloned.
-All Kubespray versions can be found on on their GitHub [release page](https://github.com/kubernetes-sigs/kubespray/releases).
-
-```yaml
-kubernetes:
-  kubespray:
-    version: v2.20.0
-```
-
-### Kubespray URL
-
-:material-tag-arrow-up-outline: [v2.0.0][tag 2.0.0]
-&ensp;
-:octicons-file-symlink-file-24: Default: `https://github.com/kubernetes-sigs/kubespray`
-
-By default, Kubespray is cloned from the official GitHub repository.
-If there is a need to use a custom forked version of the project, the url to the repository can be specified with this property.
-
-```yaml
-kubernetes:
-  kubespray:
-    url: https://github.com/kubernetes-sigs/kubespray
-```
 
 ### Kubernetes version
 
 :material-tag-arrow-up-outline: [v2.0.0][tag 2.0.0]
 &ensp;
-:material-alert-circle-outline: Required
+:octicons-file-symlink-file-24: Default: `v1.25.6`
 
-The Kubernetes version must be defined in the Kubitect configuration.
-It must be ensured that Kubespray supports the provided Kubernetes version, otherwise the cluster setup will fail.
-In addition, Kubernetes version must be prefixed with the `v`.
+Kubernetes version to be deployed.
 
 ```yaml
 kubernetes:
-  version: v1.23.6
+  version: v1.24.7
 ```
 
 ### Kubernetes network plugin
@@ -125,19 +91,6 @@ Therefore, the control plane certificates can be renewed automatically on the fi
 kubernetes:
   other:
     autoRenewCertificates: true
-```
-
-## Example usage
-
-### Minimal configuration
-
-The minimalistic Kubernetes configuration encompasses setting Kubernetes and Kubesrpay versions.
-
-```yaml
-kuberentes:
-  version: v1.23.7
-  kubespray:
-    version: v2.20.0
 ```
 
 </div>

--- a/docs/user-guide/management/upgrading.md
+++ b/docs/user-guide/management/upgrading.md
@@ -18,23 +18,15 @@ kubitect export config --cluster my-cluster > my-cluster.yaml
 ## Upgrade the cluster
 
 !!! warning "Important"
+    Do not skip Kubitect's minor releases when upgrading the cluster.
 
-    Do not skip releases when upgrading--upgrade by one tag at a time.
-
-    > For more information read [Kubespray upgrades](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/upgrades.md).
-
-Before upgrading the cluster, ensure that [Kubespray](https://github.com/kubernetes-sigs/kubespray#supported-components) supports a specific Kubernetes version.
-
-In the cluster configuration file, set the desired Kubernetes version and adjust the Kubespray version if necessary.
+In the cluster configuration file, change the Kubernetes version.
 
 Example:
 ```yaml title="cluster.yaml"
 kubernetes:
   version: v1.22.5 # Old value: v1.21.6
   ...
-  kubespray:
-    version: v2.18.0 # Old value: v2.17.1
-    ...
 ```
 
 Apply the modified configuration using `upgrade` action.

--- a/docs/user-guide/reference/configuration.md
+++ b/docs/user-guide/reference/configuration.md
@@ -17,7 +17,7 @@ The configuration sections are as follows:
 + `kubitect` - Project metadata.
 + `hosts` - A list of physical hosts (local or remote).
 + `cluster` - Configuration of the cluster infrastructure. Virtual machine properties, node types to install, and the host on which to install the nodes.
-+ `kubernetes` - Kubernetes and Kubespray configuration.
++ `kubernetes` - Kubernetes configuration.
 + `addons` - Configurable addons and applications.
 
 Each configuration property is documented with 5 columns: Property name, description, type, default value and is the property required.
@@ -769,23 +769,6 @@ Each configuration property is documented with 5 columns: Property name, descrip
       </td>
     </tr>
     <tr>
-      <td><code>kubernetes.kubespray.url</code></td>
-      <td>string</td>
-      <td><a href="https://github.com/kubernetes-sigs/kubespray.git">https://github.com/kubernetes-sigs/kubespray.git</a></td>
-      <td></td>
-      <td>
-        URL to the Kubespray project.
-        For example, it can be changed so that it targets your fork of a project.
-      </td>
-    </tr>
-    <tr>
-      <td><code>kubernetes.kubespray.version</code></td>
-      <td>string</td>
-      <td></td>
-      <td>Yes</td>
-      <td>Kubespray version. Version is used to checkout into appropriate branch.</td>
-    </tr>
-    <tr>
       <td><code>kubernetes.networkPlugin</code></td>
       <td>string</td>
       <td>calico</td>
@@ -824,8 +807,8 @@ Each configuration property is documented with 5 columns: Property name, descrip
     <tr>
       <td><code>kubernetes.version</code></td>
       <td>string</td>
+      <td>v1.25.6</td>
       <td></td>
-      <td>Yes</td>
       <td>Kubernetes version that will be installed.</td>
     </tr>
   </tbody>


### PR DESCRIPTION
To ensure compatibility and test various cluster topologies with different versions of Kubernetes, each Kubitect version is bundled with a fixed version of Kubespray.