### PR TITLE
Remove support for kubedns

### DIFF
--- a/docs/examples/full-example.md
+++ b/docs/examples/full-example.md
@@ -173,7 +173,7 @@ cluster:
 kubernetes:
   version: v1.24.7
   networkPlugin: calico
-  dnsMode: coredns
+  dnsMode: coredns # (36)!
   other:
     copyKubeconfig: false
 
@@ -294,3 +294,5 @@ addons:
 34. Resource pool name that must be defined on the host on which the instance will be deployed.
 
 35. Node labels defined for specific instances take precedence over default labels with the same key, so this label overrides the default label.
+
+36. Currently, the only DNS mode supported is CoreDNS.

--- a/docs/user-guide/configuration/kubernetes.md
+++ b/docs/user-guide/configuration/kubernetes.md
@@ -53,9 +53,8 @@ kubernetes:
 &ensp;
 :octicons-file-symlink-file-24: Default: `coredns`
 
-Two DNS servers are supproted, `coredns` and `kubedns`.
-It is highly recommended to use CoreDNS, which has replaced the kube-dns.
-If this property is omitted, CoreDNS is used.
+Currently, the only DNS mode supported by Kubitect is `coredns`.
+Therefore, it is safe to omit this property.
 
 ```yaml
 kubernetes:

--- a/docs/user-guide/reference/configuration.md
+++ b/docs/user-guide/reference/configuration.md
@@ -764,7 +764,6 @@ Each configuration property is documented with 5 columns: Property name, descrip
         DNS server used within a Kubernetes cluster. Possible values are: 
         <ul>
           <li><code>coredns</code></li>
-          <li><code>kubedns</code></li>
         </ul>
       </td>
     </tr>

--- a/pkg/cluster/provisioner/terraform/terraform.go
+++ b/pkg/cluster/provisioner/terraform/terraform.go
@@ -251,7 +251,6 @@ func (t *terraform) runCmd(action string, args []string, showOutput bool) (int, 
 	cmd.Dir = t.projectDir
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		// TODO: find a better way to handle Ctrl+C 😂?!?
 		Pdeathsig: syscall.SIGTERM,
 	}
 

--- a/pkg/config/modelconfig/kubernetes.go
+++ b/pkg/config/modelconfig/kubernetes.go
@@ -2,6 +2,7 @@ package modelconfig
 
 import (
 	"fmt"
+
 	"github.com/MusicDin/kubitect/pkg/env"
 	"github.com/MusicDin/kubitect/pkg/utils/defaults"
 	"github.com/MusicDin/kubitect/pkg/utils/validation"
@@ -49,11 +50,10 @@ type DnsMode string
 
 const (
 	COREDNS DnsMode = "coredns"
-	KUBEDNS DnsMode = "kubedns"
 )
 
 func (m DnsMode) Validate() error {
-	return validation.Var(m, validation.OneOf(COREDNS, KUBEDNS))
+	return validation.Var(m, validation.OneOf(COREDNS))
 }
 
 type NetworkPlugin string

--- a/pkg/config/modelconfig/kubernetes_test.go
+++ b/pkg/config/modelconfig/kubernetes_test.go
@@ -1,9 +1,10 @@
 package modelconfig
 
 import (
+	"testing"
+
 	"github.com/MusicDin/kubitect/pkg/env"
 	"github.com/MusicDin/kubitect/pkg/utils/defaults"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -61,13 +62,4 @@ func TestDefault(t *testing.T) {
 	k := Kubernetes{}
 	assert.NoError(t, defaults.Set(&k))
 	assert.Equal(t, COREDNS, k.DnsMode)
-}
-
-func TestDefault_Fail(t *testing.T) {
-	dns := KUBEDNS
-	k := Kubernetes{
-		DnsMode: dns,
-	}
-	assert.NoError(t, defaults.Set(&k))
-	assert.Equal(t, KUBEDNS, k.DnsMode)
 }


### PR DESCRIPTION
DNS mode `kubedns` is no longer supported.