### PR TITLE
Update cluster names in configuration examples

### DIFF
--- a/docs/examples/multi-master-cluster.md
+++ b/docs/examples/multi-master-cluster.md
@@ -78,7 +78,7 @@ By default, the load balancer is configured to distribute traffic received on po
           type: local
 
     cluster:
-      name: local-k8s-cluster
+      name: k8s-cluster
       network:
         mode: nat
         cidr: 192.168.113.0/24

--- a/docs/examples/multi-worker-cluster.md
+++ b/docs/examples/multi-worker-cluster.md
@@ -52,7 +52,7 @@ cluster:
           type: local
 
     cluster:
-      name: local-k8s-cluster
+      name: k8s-cluster
       network:
         mode: nat
         cidr: 192.168.113.0/24

--- a/docs/examples/single-node-cluster.md
+++ b/docs/examples/single-node-cluster.md
@@ -45,7 +45,7 @@ cluster:
           type: local
 
     cluster:
-      name: local-k8s-cluster
+      name: k8s-cluster
       network:
         mode: nat
         cidr: 192.168.113.0/24

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -93,7 +93,7 @@ Let's take a look at the following configuration:
 
 ```yaml title="kubitect.yaml"
 cluster:
-  name: local-k8s-cluster
+  name: k8s-cluster
   network:
     ...
   nodeTemplate:
@@ -242,7 +242,7 @@ hosts:
       type: local
 
 cluster:
-  name: local-k8s-cluster
+  name: k8s-cluster
   network:
     mode: nat
     cidr: 192.168.113.0/24

--- a/docs/getting-started/other/troubleshooting.md
+++ b/docs/getting-started/other/troubleshooting.md
@@ -278,7 +278,7 @@
 
     !!! failure "Error"
 
-        Error: error deleting storage pool: failed to remove pool '/var/lib/libvirt/images/local-k8s-cluster-main-resource-pool': Directory not empty
+        Error: error deleting storage pool: failed to remove pool '/var/lib/libvirt/images/k8s-cluster-main-resource-pool': Directory not empty
 
 === ":material-information-outline: Explanation"
 
@@ -293,27 +293,27 @@
 
         1. Make sure the pool is running.
         ```sh
-        virsh pool-start --pool local-k8s-cluster-main-resource-pool
+        virsh pool-start --pool k8s-cluster-main-resource-pool
         ```
 
         2. List volumes in the pool.
         ```sh
-        virsh vol-list --pool local-k8s-cluster-main-resource-pool
+        virsh vol-list --pool k8s-cluster-main-resource-pool
 
         #  Name         Path
         # -------------------------------------------------------------------------------------
-        #  base_volume  /var/lib/libvirt/images/local-k8s-cluster-main-resource-pool/base_volume
+        #  base_volume  /var/lib/libvirt/images/k8s-cluster-main-resource-pool/base_volume
         ```
 
         3. Delete listed volumes from the pool.
         ```sh
-        virsh vol-delete --pool local-k8s-cluster-main-resource-pool --vol base_volume
+        virsh vol-delete --pool k8s-cluster-main-resource-pool --vol base_volume
         ```
 
         4. Destroy and undefine the pool.
         ```sh
-        virsh pool-destroy --pool local-k8s-cluster-main-resource-pool
-        virsh pool-undefine --pool local-k8s-cluster-main-resource-pool
+        virsh pool-destroy --pool k8s-cluster-main-resource-pool
+        virsh pool-undefine --pool k8s-cluster-main-resource-pool
         ```
 
 

--- a/docs/user-guide/configuration/cluster-name.md
+++ b/docs/user-guide/configuration/cluster-name.md
@@ -23,6 +23,9 @@ cluster:
 ```
 
 For example, the name of each virtual machine is generated as `<cluster.name>-<node.type>-<node.instance.id>`.
-This way, the master node with ID `1` would result in `my-cluster-master-1`.
+This means that the virtual machine name of the master node with ID `1` would result in `my-cluster-master-1`.
+
+!!! Note
+    Cluster name cannot contain prefix `local`, as it is reserved for local clusters (created with `--local` flag).
 
 </div>

--- a/docs/user-guide/configuration/cluster-nodes.md
+++ b/docs/user-guide/configuration/cluster-nodes.md
@@ -532,10 +532,10 @@ cluster:
 Node roles can be seen by listing cluster nodes with `kubectl`.
 
 ```
-NAME                         STATUS   ROLES                  AGE   VERSION
-local-k8s-cluster-master-1   Ready    control-plane,master   19m   v1.22.6
-local-k8s-cluster-worker-1   Ready    node                   19m   v1.22.6
-local-k8s-cluster-worker-2   Ready    node                   19m   v1.22.6
+NAME                   STATUS   ROLES                  AGE   VERSION
+k8s-cluster-master-1   Ready    control-plane,master   19m   v1.22.6
+k8s-cluster-worker-1   Ready    node                   19m   v1.22.6
+k8s-cluster-worker-2   Ready    node                   19m   v1.22.6
 ```
 
 ### Load balance HTTP requests

--- a/docs/user-guide/reference/configuration.md
+++ b/docs/user-guide/reference/configuration.md
@@ -179,7 +179,11 @@ Each configuration property is documented with 5 columns: Property name, descrip
       <td>string</td>
       <td></td>
       <td>Yes</td>
-      <td>Custom cluster name that is used as a prefix for various cluster components.</td>
+      <td>
+        Custom cluster name that is used as a prefix for various cluster components.
+        <br/>
+        <i>Note: cluster name cannot contain prefix <code>local</code>.</i>
+      </td>
     </tr>
     <!-- Cluster network -->
     <tr>


### PR DESCRIPTION
Update cluster names in configuration examples. Cluster names can no longer contain prefix `local`.