### PR TITLE
Fix unsupported CoreDNS version

### DIFF
--- a/pkg/cluster/executors/kubespray/template.go
+++ b/pkg/cluster/executors/kubespray/template.go
@@ -43,6 +43,8 @@ func (t KubesprayAllTemplate) Template() string {
 		loadbalancer_apiserver:
 			address: "{{ .InfraNodes.LoadBalancer.VIP }}"
 			port: 6443
+		# CoreDNS version 1.9.3 is not supported on Kubernetes version 1.23 - 1.25.
+		coredns_version: "v1.8.6"
 		## Upstream dns servers
 		# upstream_dns_servers:
 		#   - 8.8.8.8


### PR DESCRIPTION
CoreDNS version 1.9.3 does not support Kubernetes versions lower than 1.25.0, which results in upgrades from Kubernetes 1.23.x to 1.24.x to fail.

To resolve this issue, CoreDNS version is lowered to `v1.8.6`.
