### PR TITLE
Always output Terraform error

### DIFF
--- a/pkg/cluster/provisioner/terraform/terraform.go
+++ b/pkg/cluster/provisioner/terraform/terraform.go
@@ -255,9 +255,9 @@ func (t *terraform) runCmd(action string, args []string, showOutput bool) (int, 
 		Pdeathsig: syscall.SIGTERM,
 	}
 
+	cmd.Stderr = ui.Streams().Err().File()
 	if showOutput || ui.Debug() {
 		cmd.Stdout = ui.Streams().Out().File()
-		cmd.Stderr = ui.Streams().Err().File()
 	}
 
 	err := cmd.Run()


### PR DESCRIPTION
If an error is encountered during the `terraform plan` phase, Kubitect throws an error that is not very intuitive. To ensure that errors are properly explained in these situations, the error message thrown by Terraform should always be displayed.

Previously:

```
┌
│ Error: terraform plan failed: exit status 1
└
```

Now:
```
╷
│ Error: failed to dial libvirt: dial tcp 123.123.123.123:22: i/o timeout
│ 
│   with provider["registry.terraform.io/dmacvicar/libvirt"].hostX,
│   on main.tf line 29, in provider "libvirt":
│   29: provider "libvirt"
│ 
╵
┌
│ Error: terraform plan failed: exit status 1
└
```
