### PR TITLE
Allow addition and deletion of hosts during scaling

### DIFF
--- a/pkg/cluster/action_apply.go
+++ b/pkg/cluster/action_apply.go
@@ -161,7 +161,7 @@ func (c *Cluster) create() error {
 		return err
 	}
 
-	if err := c.Provisioner().Init(); err != nil {
+	if err := c.Provisioner().Init(nil); err != nil {
 		return err
 	}
 
@@ -174,6 +174,10 @@ func (c *Cluster) create() error {
 	}
 
 	if err := c.Executor().Init(); err != nil {
+		return err
+	}
+
+	if err := c.Executor().Sync(); err != nil {
 		return err
 	}
 
@@ -182,7 +186,7 @@ func (c *Cluster) create() error {
 
 // upgrade upgrades an existing cluster.
 func (c *Cluster) upgrade() error {
-	if err := c.Provisioner().Init(); err != nil {
+	if err := c.Provisioner().Init(nil); err != nil {
 		return err
 	}
 
@@ -195,6 +199,10 @@ func (c *Cluster) upgrade() error {
 	}
 
 	if err := c.Executor().Init(); err != nil {
+		return err
+	}
+
+	if err := c.Executor().Sync(); err != nil {
 		return err
 	}
 
@@ -211,7 +219,7 @@ func (c *Cluster) scale(events event.Events) error {
 		return err
 	}
 
-	if err := c.Provisioner().Init(); err != nil {
+	if err := c.Provisioner().Init(events); err != nil {
 		return err
 	}
 
@@ -220,6 +228,10 @@ func (c *Cluster) scale(events event.Events) error {
 	}
 
 	if err := c.Sync(); err != nil {
+		return err
+	}
+
+	if err := c.Executor().Sync(); err != nil {
 		return err
 	}
 

--- a/pkg/cluster/event/events_list.go
+++ b/pkg/cluster/event/events_list.go
@@ -30,6 +30,17 @@ var ScaleEvents = Events{
 		action: cmp.CREATE,
 		path:   "Cluster.Nodes.LoadBalancer.Instances.*",
 	},
+	// Allow addition and deletion of hosts
+	{
+		eType:  OK,
+		action: cmp.CREATE,
+		path:   "Hosts.*",
+	},
+	{
+		eType:  OK,
+		action: cmp.DELETE,
+		path:   "Hosts.*",
+	},
 }
 
 var ModifyEvents = Events{

--- a/pkg/cluster/event/events_mock.go
+++ b/pkg/cluster/event/events_mock.go
@@ -6,7 +6,7 @@ import (
 	"github.com/MusicDin/kubitect/pkg/utils/cmp"
 )
 
-func MockEvent(t *testing.T, eventType EventType, changes []cmp.Change) Event {
+func MockEvent(t *testing.T, eventType EventType, action cmp.ActionType, changes []cmp.Change) Event {
 	t.Helper()
 
 	return Event{
@@ -14,6 +14,6 @@ func MockEvent(t *testing.T, eventType EventType, changes []cmp.Change) Event {
 		changes: changes,
 		path:    t.TempDir(),
 		msg:     "mock event",
-		action:  cmp.MODIFY,
+		action:  action,
 	}
 }

--- a/pkg/cluster/event/events_test.go
+++ b/pkg/cluster/event/events_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMockEvent(t *testing.T) {
-	assert.NotNil(t, MockEvent(t, OK, nil))
+	assert.NotNil(t, MockEvent(t, OK, cmp.MODIFY, nil))
 }
 
 func TestEvent_Path(t *testing.T) {

--- a/pkg/cluster/executors/executor.go
+++ b/pkg/cluster/executors/executor.go
@@ -4,6 +4,7 @@ import "github.com/MusicDin/kubitect/pkg/cluster/event"
 
 type Executor interface {
 	Init() error
+	Sync() error
 	Create() error
 	Upgrade() error
 	ScaleUp(event.Events) error

--- a/pkg/cluster/executors/executor_mock.go
+++ b/pkg/cluster/executors/executor_mock.go
@@ -9,6 +9,7 @@ import (
 type executorMock struct{}
 
 func (m executorMock) Init() error                  { return nil }
+func (m executorMock) Sync() error                  { return nil }
 func (m executorMock) Create() error                { return nil }
 func (m executorMock) Upgrade() error               { return nil }
 func (m executorMock) ScaleDown(event.Events) error { return nil }

--- a/pkg/cluster/executors/kubespray/kubespray.go
+++ b/pkg/cluster/executors/kubespray/kubespray.go
@@ -218,7 +218,7 @@ func (e *kubespray) generateNodesInventory() error {
 
 // generateHostsInventory creates an Ansible inventory of target hosts.
 func (e *kubespray) generateHostsInventory() error {
-	return NewHostsTemplate(e.ConfigDir, e.SshPrivateKeyPath, e.Config.Hosts).Write()
+	return NewHostsTemplate(e.ConfigDir, e.Config.Hosts).Write()
 }
 
 // generateGroupVars creates a directory of Kubespray group variables.

--- a/pkg/cluster/executors/kubespray/kubespray_test.go
+++ b/pkg/cluster/executors/kubespray/kubespray_test.go
@@ -68,7 +68,7 @@ func MockEvents(t *testing.T, obj interface{}, eType event.EventType) []event.Ev
 	}
 
 	return []event.Event{
-		event.MockEvent(t, eType, changes),
+		event.MockEvent(t, eType, cmp.MODIFY, changes),
 	}
 }
 

--- a/pkg/cluster/executors/kubespray/template.go
+++ b/pkg/cluster/executors/kubespray/template.go
@@ -149,16 +149,14 @@ func (t KubesprayEtcdTemplate) Template() string {
 }
 
 type HostsTemplate struct {
-	configDir  string
-	SshKeyFile string
-	Hosts      []modelconfig.Host
+	configDir string
+	Hosts     []modelconfig.Host
 }
 
-func NewHostsTemplate(configDir, sshPrivateKeyPath string, hosts []modelconfig.Host) HostsTemplate {
+func NewHostsTemplate(configDir string, hosts []modelconfig.Host) HostsTemplate {
 	return HostsTemplate{
-		configDir:  configDir,
-		SshKeyFile: sshPrivateKeyPath,
-		Hosts:      hosts,
+		configDir: configDir,
+		Hosts:     hosts,
 	}
 }
 
@@ -184,7 +182,6 @@ func isRemoteHost(host modelconfig.Host) bool {
 
 func (t HostsTemplate) Template() string {
 	return template.TrimTemplate(`
-		{{- $pkPath := .SshKeyFile -}}
 		all:
 			hosts:
 			{{- range .Hosts }}
@@ -194,7 +191,7 @@ func (t HostsTemplate) Template() string {
 					ansible_user: {{ .Connection.User }}
 					ansible_host: {{ .Connection.IP }}
 					ansible_port: {{ .Connection.SSH.Port }}
-					ansible_private_key_file: {{ $pkPath }}
+					ansible_private_key_file: {{ .Connection.SSH.Keyfile }}
 				{{- else }}
 					ansible_connection: local
 					ansible_host: localhost

--- a/pkg/cluster/executors/kubespray/template_test.go
+++ b/pkg/cluster/executors/kubespray/template_test.go
@@ -1,6 +1,7 @@
 package kubespray
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/MusicDin/kubitect/pkg/config/modelconfig"
@@ -62,10 +63,10 @@ func TestHostsTemplate(t *testing.T) {
 		modelconfig.MockRemoteHost(t, "remote", false, false),
 	}
 
-	tpl := NewHostsTemplate(t.TempDir(), "~/.ssh/id_rsa", hosts)
+	tpl := NewHostsTemplate(t.TempDir(), hosts)
 	pop, err := template.Populate(tpl)
 
-	expect := template.TrimTemplate(`
+	expect := fmt.Sprintf(template.TrimTemplate(`
 		all:
 			hosts:
 				local:
@@ -79,14 +80,14 @@ func TestHostsTemplate(t *testing.T) {
 					ansible_user: mocked-user
 					ansible_host: 192.168.113.42
 					ansible_port: 22
-					ansible_private_key_file: ~/.ssh/id_rsa
+					ansible_private_key_file: %s
 			children:
 				kubitect_hosts:
 					hosts:
 						local:
 						localhost:
 						remote:
-	`)
+	`), hosts[2].Connection.SSH.Keyfile)
 
 	assert.NoError(t, err)
 	assert.NoError(t, tpl.Write())

--- a/pkg/cluster/meta.go
+++ b/pkg/cluster/meta.go
@@ -34,26 +34,6 @@ type ClusterMeta struct {
 	prov provisioner.Provisioner
 }
 
-// func NewClusterMeta(ctx app.AppContext, clusterPath string) (ClusterMeta, error) {
-// 	cpStat, err := os.Stat(clusterPath)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("cluster meta: %v", err)
-// 	}
-
-// 	meta := clusterMeta{
-// 		AppContext: ctx,
-// 		Name:       cpStat.Name(),
-// 		Path:       filepath.Join(clusterPath, cpStat.Name()),
-// 		Local:      ctx.Local(),
-// 	}
-
-// 	if !cpStat.IsDir() || !meta.ContainsAppliedConfig() {
-// 		return nil, fmt.Errorf("cluster meta: %s is not a cluster directory", err)
-// 	}
-
-// 	return &meta, nil
-// }
-
 func (c ClusterMeta) ConfigDir() string {
 	return filepath.Join(c.Path, DefaultConfigDir)
 }

--- a/pkg/cluster/provisioner/provisioner.go
+++ b/pkg/cluster/provisioner/provisioner.go
@@ -1,7 +1,9 @@
 package provisioner
 
+import "github.com/MusicDin/kubitect/pkg/cluster/event"
+
 type Provisioner interface {
-	Init() error
+	Init(events event.Events) error
 	Plan() (bool, error)
 	Apply() error
 	Destroy() error

--- a/pkg/cluster/provisioner/provisioner_mock.go
+++ b/pkg/cluster/provisioner/provisioner_mock.go
@@ -1,13 +1,17 @@
 package provisioner
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/MusicDin/kubitect/pkg/cluster/event"
+)
 
 type provisionerMock struct{}
 
-func (m provisionerMock) Init() error         { return nil }
-func (m provisionerMock) Plan() (bool, error) { return true, nil }
-func (m provisionerMock) Apply() error        { return nil }
-func (m provisionerMock) Destroy() error      { return nil }
+func (m provisionerMock) Init(event.Events) error { return nil }
+func (m provisionerMock) Plan() (bool, error)     { return true, nil }
+func (m provisionerMock) Apply() error            { return nil }
+func (m provisionerMock) Destroy() error          { return nil }
 
 func MockProvisioner(t *testing.T) Provisioner {
 	return provisionerMock{}


### PR DESCRIPTION
Allow addition and deletion of hosts when scaling the cluster:
- New nodes can be provisioned on new hosts
- Redundant hosts can be removed when scaling down the cluster (as long as no node is linked to the existing host)