### PR TITLE
Bump terraform and libirt provider versions

### DIFF
--- a/embed/terraform/modules/host/versions.tf
+++ b/embed/terraform/modules/host/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "~> 0.6.12"
+      version = ">= 0.6.12"
     }
   }
 }

--- a/embed/terraform/versions.tf
+++ b/embed/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3.7"
 
   backend "local" {
     path = "../config/terraform/terraform.tfstate"
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "~> 0.6.12"
+      version = "~> 0.7.1"
     }
   }
 }

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -11,7 +11,7 @@ const (
 	ConstKubesprayUrl      = "https://github.com/kubernetes-sigs/kubespray"
 	ConstKubesprayVersion  = "v2.21.0"
 	ConstKubernetesVersion = "v1.25.6"
-	ConstTerraformVersion  = "1.3.7"
+	ConstTerraformVersion  = "1.4.4"
 )
 
 // Defines applications that Kubitect depends on.


### PR DESCRIPTION
Bump versions:
- Terraform: `v1.3.7` -> `v1.4.4`
- Libvirt provider: `v0.6.12` -> `v0.7.1`