### PR TITLE
Clean up orphan resources on host removal

### DIFF
--- a/embed/terraform/main.tf.tpl
+++ b/embed/terraform/main.tf.tpl
@@ -30,6 +30,12 @@ provider "libvirt" {
   uri   = "{{ hostUri .}}"
 }
 {{- end }}
+{{ range .RemovedHosts }}
+provider "libvirt" {
+  alias = "{{ .Name }}"
+  uri   = "{{ hostUri .}}"
+}
+{{- end }}
 
 
 #======================================================================================

--- a/pkg/cluster/action_apply.go
+++ b/pkg/cluster/action_apply.go
@@ -219,6 +219,10 @@ func (c *Cluster) scale(events event.Events) error {
 		return err
 	}
 
+	if err := c.Executor().Sync(); err != nil {
+		return err
+	}
+
 	if err := c.Provisioner().Init(events); err != nil {
 		return err
 	}
@@ -228,10 +232,6 @@ func (c *Cluster) scale(events event.Events) error {
 	}
 
 	if err := c.Sync(); err != nil {
-		return err
-	}
-
-	if err := c.Executor().Sync(); err != nil {
 		return err
 	}
 

--- a/pkg/cluster/executors/kubespray/kubespray.go
+++ b/pkg/cluster/executors/kubespray/kubespray.go
@@ -107,10 +107,6 @@ func (e *kubespray) Sync() error {
 // Create creates a Kubernetes cluster by calling appropriate Kubespray
 // playbooks.
 func (e *kubespray) Create() error {
-	if err := e.KubitectHostsSetup(); err != nil {
-		return err
-	}
-
 	if err := e.HAProxy(); err != nil {
 		return err
 	}
@@ -125,10 +121,6 @@ func (e *kubespray) Create() error {
 // Upgrades upgrades a Kubernetes cluster by calling appropriate Kubespray
 // playbooks.
 func (e *kubespray) Upgrade() error {
-	if err := e.KubitectHostsSetup(); err != nil {
-		return err
-	}
-
 	if err := e.KubesprayUpgrade(); err != nil {
 		return err
 	}
@@ -142,10 +134,6 @@ func (e *kubespray) ScaleUp(events event.Events) error {
 
 	if len(events) == 0 {
 		return nil
-	}
-
-	if err := e.KubitectHostsSetup(); err != nil {
-		return err
 	}
 
 	if err := e.HAProxy(); err != nil {
@@ -173,10 +161,6 @@ func (e *kubespray) ScaleDown(events event.Events) error {
 	for _, n := range rmNodes {
 		name := fmt.Sprintf("%s-%s-%s", e.ClusterName, n.GetTypeName(), n.GetID())
 		names = append(names, name)
-	}
-
-	if err := e.KubitectHostsSetup(); err != nil {
-		return err
 	}
 
 	if err := e.generateGroupVars(); err != nil {

--- a/pkg/cluster/provisioner/terraform/template.go
+++ b/pkg/cluster/provisioner/terraform/template.go
@@ -11,14 +11,16 @@ import (
 )
 
 type MainTemplate struct {
-	Hosts   []modelconfig.Host
-	projDir string
+	Hosts        []modelconfig.Host
+	RemovedHosts []modelconfig.Host
+	projDir      string
 }
 
-func NewMainTemplate(projectDir string, hosts []modelconfig.Host) MainTemplate {
+func NewMainTemplate(projectDir string, hosts, removedHosts []modelconfig.Host) MainTemplate {
 	return MainTemplate{
-		Hosts:   hosts,
-		projDir: projectDir,
+		Hosts:        hosts,
+		RemovedHosts: removedHosts,
+		projDir:      projectDir,
 	}
 }
 

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -21,16 +21,11 @@ var ProjectRequiredApps = []string{
 	"git",
 }
 
-// Defines required files/directories that are copied from tmp git project.
+// Defines required files/directories that are copied from embedded
+// resources, when cluster is created.
 var ProjectRequiredFiles = []string{
 	"ansible/",
-	"terraform/modules/",
-	"terraform/templates/",
-	"terraform/scripts/",
-	"terraform/main.tf.tpl",
-	"terraform/output.tf",
-	"terraform/variables.tf",
-	"terraform/versions.tf",
+	"terraform/",
 }
 
 // Defines options for "apply --action" command.


### PR DESCRIPTION
When a host is removed, the data pools remain intact, which can cause Terraform to fail during the next apply. 
To prevent this issue, removed hosts should only be used for configuring Terraform providers.