### PR TITLE
Fix inventory generation after scaling

### DIFF
--- a/pkg/cluster/action_apply.go
+++ b/pkg/cluster/action_apply.go
@@ -219,10 +219,6 @@ func (c *Cluster) scale(events event.Events) error {
 		return err
 	}
 
-	if err := c.Executor().Sync(); err != nil {
-		return err
-	}
-
 	if err := c.Provisioner().Init(events); err != nil {
 		return err
 	}
@@ -232,6 +228,10 @@ func (c *Cluster) scale(events event.Events) error {
 	}
 
 	if err := c.Sync(); err != nil {
+		return err
+	}
+
+	if err := c.Executor().Sync(); err != nil {
 		return err
 	}
 

--- a/pkg/cluster/executors/kubespray/kubespray.go
+++ b/pkg/cluster/executors/kubespray/kubespray.go
@@ -171,7 +171,7 @@ func (e *kubespray) ScaleDown(events event.Events) error {
 		return err
 	}
 
-	return nil
+	return e.generateNodesInventory()
 }
 
 // extractRemovedNodes returns node instances from the event changes.


### PR DESCRIPTION
Update only nodes inventory after removing nodes from the cluster and ensure that all inventories are updated after infrastructure scaling.