### PR TITLE
Increase versions of OS distros

### DIFF
--- a/docs/user-guide/configuration/cluster-node-template.md
+++ b/docs/user-guide/configuration/cluster-node-template.md
@@ -55,10 +55,10 @@ cluster:
 Available OS distribution presets are the following:
 
 + `ubuntu` - Latest Ubuntu 22.04 release. (*default*)
-+ `ubuntu22` - Ubuntu 22.04 release *2022-07-12*.
-+ `ubuntu20` - Ubuntu 20.04 release *2022-07-11*.
++ `ubuntu22` - Ubuntu 22.04 release *2023-03-02*.
++ `ubuntu20` - Ubuntu 20.04 release *2023-02-09*.
 + `debian` - Latest Debian 11 release.
-+ `debian11` - Debian 11 release *2022-07-11*.
++ `debian11` - Debian 11 release *2023-01-24*.
 
 Ubuntu images are downloaded from the [Ubuntu cloud image repository](https://cloud-images.ubuntu.com/) and Debian images are downloaded from the [Debian cloud image repository](https://cloud.debian.org/images/cloud/).
 

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -40,7 +40,7 @@ var ProjectOsPresets = map[string]string{
 	"ubuntu22": "https://cloud-images.ubuntu.com/releases/jammy/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img",
 	"ubuntu20": "https://cloud-images.ubuntu.com/releases/focal/release-20230209/ubuntu-20.04-server-cloudimg-amd64.img",
 	"debian":   "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-amd64.qcow2",
-	"debian11": "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-generic-amd64-20230124-1270.qcow2",
+	"debian11": "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-genericcloud-amd64-20230124-1270.qcow2",
 }
 
 var ProjectK8sVersions = []string{

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -37,10 +37,10 @@ var ProjectApplyActions = [...]string{
 
 var ProjectOsPresets = map[string]string{
 	"ubuntu":   "https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img",
-	"ubuntu22": "https://cloud-images.ubuntu.com/releases/jammy/release-20220712/ubuntu-22.04-server-cloudimg-amd64.img",
-	"ubuntu20": "https://cloud-images.ubuntu.com/releases/focal/release-20220711/ubuntu-20.04-server-cloudimg-amd64.img",
+	"ubuntu22": "https://cloud-images.ubuntu.com/releases/jammy/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img",
+	"ubuntu20": "https://cloud-images.ubuntu.com/releases/focal/release-20230209/ubuntu-20.04-server-cloudimg-amd64.img",
 	"debian":   "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-amd64.qcow2",
-	"debian11": "https://cloud.debian.org/images/cloud/bullseye/20220711-1073/debian-11-genericcloud-amd64-20220711-1073.qcow2",
+	"debian11": "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-generic-amd64-20230124-1270.qcow2",
 }
 
 var ProjectK8sVersions = []string{


### PR DESCRIPTION
Bump versions of OS distros:
- Ubuntu20.04: `2022-07-11` -> `2023-02-09`
- Ubuntu22.04: `2022-07-12` -> `2023-03-02`
- Debian11: `2022-07-11` -> `2023-01-24`