### PR TITLE
Enable CPU mode validation and add missing modes

### DIFF
--- a/pkg/models/config/cluster_node_template.go
+++ b/pkg/models/config/cluster_node_template.go
@@ -19,8 +19,9 @@ func (n NodeTemplate) Validate() error {
 	return v.Struct(&n,
 		v.Field(&n.User),
 		v.Field(&n.OS),
-		v.Field(&n.DNS),
 		v.Field(&n.SSH),
+		v.Field(&n.CpuMode),
+		v.Field(&n.DNS),
 	)
 }
 
@@ -93,10 +94,12 @@ func (ssh *NodeTemplateSSH) SetDefaults() {
 type CpuMode string
 
 const (
-	CUSTOM      CpuMode = "custom"
-	PASSTHROUGH CpuMode = "host-passthrough"
+	CUSTOM           CpuMode = "custom"
+	HOST_MODEL       CpuMode = "host-model"
+	HOST_PASSTHROUGH CpuMode = "host-passthrough"
+	MAXIMUM          CpuMode = "maximum"
 )
 
 func (m CpuMode) Validate() error {
-	return v.Var(m, v.OneOf(PASSTHROUGH, CUSTOM))
+	return v.Var(m, v.OneOf(CUSTOM, HOST_MODEL, HOST_PASSTHROUGH, MAXIMUM))
 }

--- a/pkg/models/config/cluster_node_template_test.go
+++ b/pkg/models/config/cluster_node_template_test.go
@@ -61,11 +61,12 @@ func TestNodeTemplateSSH(t *testing.T) {
 
 	assert.NoError(t, NodeTemplateSSH{}.Validate())
 	assert.NoError(t, nts1.Validate())
-	// assert.EqualError(t, nts2.Validate(), "Field 'privateKeyPath' must be a valid file path that points to an existing file. (actual: ./non-existing)")
 	assert.NoError(t, nts2.Validate())
 }
 
 func TestCpuMode(t *testing.T) {
-	assert.NoError(t, CpuMode(PASSTHROUGH).Validate())
 	assert.NoError(t, CpuMode("custom").Validate())
+	assert.NoError(t, CpuMode(HOST_PASSTHROUGH).Validate())
+	assert.NoError(t, CpuMode("host-model").Validate())
+	assert.NoError(t, CpuMode("maximum").Validate())
 }


### PR DESCRIPTION
Enable CPU mode validation in the configuration file and add support for `host-model` and `maximum` CPU modes.