### PR TITLE
Fix unknown Pdeathsig field on darwin

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -4,7 +4,13 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/pkg/cluster/provisioner/terraform/cmd_default.go
+++ b/pkg/cluster/provisioner/terraform/cmd_default.go
@@ -1,0 +1,43 @@
+//go:build !linux
+// +build !linux
+
+package terraform
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+
+	"github.com/MusicDin/kubitect/pkg/ui"
+)
+
+// runCmd runs terraform command and returns exit code with
+// a potential error.
+func (t *terraform) runCmd(action string, args []string, showOutput bool) (int, error) {
+	args = append([]string{action}, args...)
+
+	if !ui.HasColor() {
+		args = append(args, flag("no-color"))
+	}
+
+	cmd := exec.Command(t.binPath, args...)
+	cmd.Dir = t.projectDir
+
+	cmd.Stderr = ui.Streams().Err().File()
+	if showOutput || ui.Debug() {
+		cmd.Stdout = ui.Streams().Out().File()
+	}
+
+	if ui.Debug() {
+		cmd.Env = append(cmd.Env, "TF_LOG=INFO")
+	}
+
+	err := cmd.Run()
+	exitCode := cmd.ProcessState.ExitCode()
+
+	if err != nil {
+		err = fmt.Errorf("terraform %s failed: %v", action, err)
+	}
+
+	return exitCode, err
+}

--- a/pkg/cluster/provisioner/terraform/cmd_default.go
+++ b/pkg/cluster/provisioner/terraform/cmd_default.go
@@ -6,7 +6,6 @@ package terraform
 import (
 	"fmt"
 	"os/exec"
-	"syscall"
 
 	"github.com/MusicDin/kubitect/pkg/ui"
 )

--- a/pkg/cluster/provisioner/terraform/cmd_linux.go
+++ b/pkg/cluster/provisioner/terraform/cmd_linux.go
@@ -1,0 +1,44 @@
+package terraform
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+
+	"github.com/MusicDin/kubitect/pkg/ui"
+)
+
+// runCmd runs terraform command and returns exit code with
+// a potential error.
+func (t *terraform) runCmd(action string, args []string, showOutput bool) (int, error) {
+	args = append([]string{action}, args...)
+
+	if !ui.HasColor() {
+		args = append(args, flag("no-color"))
+	}
+
+	cmd := exec.Command(t.binPath, args...)
+	cmd.Dir = t.projectDir
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
+
+	cmd.Stderr = ui.Streams().Err().File()
+	if showOutput || ui.Debug() {
+		cmd.Stdout = ui.Streams().Out().File()
+	}
+
+	if ui.Debug() {
+		cmd.Env = append(cmd.Env, "TF_LOG=INFO")
+	}
+
+	err := cmd.Run()
+	exitCode := cmd.ProcessState.ExitCode()
+
+	if err != nil {
+		err = fmt.Errorf("terraform %s failed: %v", action, err)
+	}
+
+	return exitCode, err
+}

--- a/pkg/cluster/provisioner/terraform/terraform.go
+++ b/pkg/cluster/provisioner/terraform/terraform.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
-	"syscall"
 
 	"github.com/MusicDin/kubitect/pkg/cluster/event"
 	"github.com/MusicDin/kubitect/pkg/cluster/provisioner"
@@ -244,41 +242,6 @@ func installTerraform(ver, binDir string) (string, error) {
 	}
 
 	return installer.Install(context.Background())
-}
-
-// runCmd runs terraform command and returns exit code with
-// a potential error.
-func (t *terraform) runCmd(action string, args []string, showOutput bool) (int, error) {
-	args = append([]string{action}, args...)
-
-	if !ui.HasColor() {
-		args = append(args, flag("no-color"))
-	}
-
-	cmd := exec.Command(t.binPath, args...)
-	cmd.Dir = t.projectDir
-
-	if ui.Debug() {
-		cmd.Env = append(cmd.Env, "TF_LOG=INFO")
-	}
-
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGTERM,
-	}
-
-	cmd.Stderr = ui.Streams().Err().File()
-	if showOutput || ui.Debug() {
-		cmd.Stdout = ui.Streams().Out().File()
-	}
-
-	err := cmd.Run()
-	exitCode := cmd.ProcessState.ExitCode()
-
-	if err != nil {
-		err = fmt.Errorf("terraform %s failed: %v", action, err)
-	}
-
-	return exitCode, err
 }
 
 // Flag concatenates key and value with "=" if value is provided.


### PR DESCRIPTION
Resolve the unrecognized `Pdeathsig` field issue on Darwin and execute Go tests on macOS.