### PR TITLE
Add RHEL based distro support

### DIFF
--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -151,7 +151,9 @@ While there are no required fields, there are several useful properties you may 
 
 + `os.distro` 
 
-    This property defines the operating system for the nodes. Currently, only Ubuntu and Debian are supported, and by default, the latest Ubuntu 22.04 release is used.
+    This property defines the operating system for the nodes. 
+    By default, the nodes use the latest Ubuntu 22.04 release. 
+    To explore other available distributions, please refer to the [OS Distribution](../../user-guide/configuration/cluster-node-template#os-distribution) section in the node template of our user guide.
 
 + `ssh.addToKnownHosts`
 

--- a/docs/user-guide/configuration/cluster-node-template.md
+++ b/docs/user-guide/configuration/cluster-node-template.md
@@ -40,9 +40,9 @@ cluster:
 :octicons-file-symlink-file-24: Default: `ubuntu`
 
 The operating system for virtual machines can be specified in the node template. 
-Currently, you can configure either Ubuntu or Debian. 
 By default, the Ubuntu distribution is installed on all virtual machines.
-To use Debian instead, set the `os.distro` property to Debian.
+
+You can select a desired distribution by setting the `os.distro` property.
 
 ```yaml
 cluster:
@@ -53,15 +53,32 @@ cluster:
 
 1. By default, `ubuntu` is used.
 
+
 The available operating system distribution presets are:
 
-+ `ubuntu` - Latest Ubuntu 22.04 release. (default)
++ **`ubuntu`** - Latest Ubuntu 22.04 release. (default)
 + `ubuntu22` - Ubuntu 22.04 release as of *2023-03-02*.
 + `ubuntu20` - Ubuntu 20.04 release as of *2023-02-09*.
-+ `debian` - Latest Debian 11 release.
++ **`debian`** - Latest Debian 11 release.
 + `debian11` - Debian 11 release as of *2023-01-24*.
++ **`rocky`** - Latest Rocky 9 release.
++ `rocky9` - Rocky 9.1 release as of *2023-02-15*.
++ **`centos9`** - CentOS Stream 9 release as of *2023-04-05*.
 
-Note that Ubuntu images are downloaded from the [Ubuntu cloud image repository](https://cloud-images.ubuntu.com/) and Debian images are downloaded from the [Debian cloud image repository](https://cloud.debian.org/images/cloud/).
+!!! warning "Important"
+
+    Rocky Linux and CentOS Stream both require the `x86-64-v2` instruction set to run.
+    If the [CPU mode property](#cpu-mode) is not set to `host-passthrough`, `host-model`, or `maximum`, the virtual machine may not be able to boot properly.
+
+
+??? question "Where are images downloaded from? <i class="click-tip"></i>"
+
+    Images are sourced from the official cloud image repository for the corresponding Linux distribution.
+
+    - Ubuntu: [Ubuntu cloud image repository](https://cloud-images.ubuntu.com/)
+    - Debian: [Debian cloud image repository](https://cloud.debian.org/images/cloud/)
+    - CentOS: [CentOS cloud image repositroy](https://cloud.centos.org/centos/)
+    - Rocky: [Rocky cloud image repositroy](https://dl.rockylinux.org/pub/rocky/)
 
 #### OS source
 

--- a/docs/user-guide/reference/configuration.md
+++ b/docs/user-guide/reference/configuration.md
@@ -648,11 +648,13 @@ Each configuration property is documented with 5 columns: Property name, descrip
         Set OS distribution. Possible values are:
         <ul>
           <li><code>ubuntu</code></li>
+          <li><code>ubuntu22</code></li>
+          <li><code>ubuntu20</code></li>
           <li><code>debian</code></li>
-          <li>
-            <code>custom</code> - For all other distros
-            <i>(for development only)</i>
-          </li>
+          <li><code>debian11</code></li>
+          <li><code>rocky</code></li>
+          <li><code>rocky9</code></li>
+          <li><code>centos9</code></li>
         </ul>
       </td>
     </tr>

--- a/embed/ansible/kubitect/roles/haproxy/tasks/configure_haproxy.yaml
+++ b/embed/ansible/kubitect/roles/haproxy/tasks/configure_haproxy.yaml
@@ -4,6 +4,14 @@
     name: haproxy
     state: present
 
+- name: Create directory for HAProxy sockets
+  ansible.builtin.file:
+    path: /run/haproxy/
+    state: directory
+    owner: haproxy
+    group: haproxy
+    mode: 2775
+
 - name: Create HAProxy config
   vars:
     control_plane_instances: "{{ infra.nodes.master.instances }}"

--- a/embed/ansible/kubitect/roles/haproxy/tasks/main.yaml
+++ b/embed/ansible/kubitect/roles/haproxy/tasks/main.yaml
@@ -1,26 +1,26 @@
 ---
-- name: Get OS release
-  raw: cat /etc/os-release
-  register: os_release
+- name: Get operating system ID
+  raw: cat /etc/os-release | grep -i "^id="
+  register: os_id
   changed_when: false
-  environment: {}
 
-- name: Install Python3
-  raw:
-    apt update -q && \
-    DEBIAN_FRONTEND=noninteractive apt install -q -y python3
-  environment: {}
-  when:
-    - "'Ubuntu' in os_release.stdout"
-    - "'Debian' in os_release.stdout"
+- name: Configure SELinux
+  block:
+    - name: Install python3 policy core utils
+      yum:
+        name: python3-policycoreutils
+        state: present
 
-- name: Configure SELinux on CentOS
-  raw:
-    yum -q -y install python3-policycoreutils && \
-    semanage port -a -t http_port_t -p tcp 6443
-  environment: {}
+    - name: Enable configured incoming ports
+      vars:
+        ports: "{{ config.cluster.nodes.loadBalancer.forwardPorts | map(attribute='port') | default([]) }}"
+      seport:
+        ports: "{{ ports | union([ 6443 ]) }}"
+        proto: tcp
+        setype: http_port_t
+        state: present
   when:
-    - "'CentOS' in os_release.stdout"
+    - ( "'centos' in os_id.stdout" ) or ( "'rocky' in os_id.stdout" )
 
 - name: Allow binding non-local IP
   sysctl:

--- a/embed/ansible/kubitect/roles/haproxy/tasks/main.yaml
+++ b/embed/ansible/kubitect/roles/haproxy/tasks/main.yaml
@@ -2,7 +2,6 @@
 - name: Get operating system ID
   raw: cat /etc/os-release | grep -i "^id="
   register: os_id
-  changed_when: false
 
 - name: Configure SELinux
   block:
@@ -20,7 +19,7 @@
         setype: http_port_t
         state: present
   when:
-    - ( "'centos' in os_id.stdout" ) or ( "'rocky' in os_id.stdout" )
+    - ( "centos" in os_id.stdout ) or ( "rocky" in os_id.stdout )
 
 - name: Allow binding non-local IP
   sysctl:

--- a/embed/ansible/kubitect/roles/haproxy/templates/haproxy.cfg.j2
+++ b/embed/ansible/kubitect/roles/haproxy/templates/haproxy.cfg.j2
@@ -25,13 +25,6 @@ defaults
     timeout connect 5000
     timeout client  50000
     timeout server  50000
-    errorfile 400 /etc/haproxy/errors/400.http
-    errorfile 403 /etc/haproxy/errors/403.http
-    errorfile 408 /etc/haproxy/errors/408.http
-    errorfile 500 /etc/haproxy/errors/500.http
-    errorfile 502 /etc/haproxy/errors/502.http
-    errorfile 503 /etc/haproxy/errors/503.http
-    errorfile 504 /etc/haproxy/errors/504.http
 
 frontend kubernetes
         bind *:6443

--- a/embed/terraform/templates/cloud_init/cloud_init.tpl
+++ b/embed/terraform/templates/cloud_init/cloud_init.tpl
@@ -16,6 +16,11 @@ package_upgrade: ${update}
 packages:
   - qemu-guest-agent
 
+bootcmd:
+  # Disable qemu-guest-agent to prevent reporting IP addresses
+  # before cloud-init has configured the network.
+  - cloud-init-per once disable-qemu-ga systemctl stop qemu-guest-agent.service
+
 runcmd:
   - [ systemctl, enable, qemu-guest-agent.service ]
   - [ systemctl, start, qemu-guest-agent.service ]

--- a/embed/terraform/templates/cloud_init/cloud_init_network_dhcp.tpl
+++ b/embed/terraform/templates/cloud_init/cloud_init_network_dhcp.tpl
@@ -1,4 +1,3 @@
-renderer: networkd
 version: 2
 ethernets:
   ${network_interface}:

--- a/embed/terraform/templates/cloud_init/cloud_init_network_static.tpl
+++ b/embed/terraform/templates/cloud_init/cloud_init_network_static.tpl
@@ -1,4 +1,3 @@
-renderer: networkd
 version: 2
 ethernets:
   ${network_interface}:

--- a/pkg/cluster/action_destroy.go
+++ b/pkg/cluster/action_destroy.go
@@ -25,10 +25,13 @@ func (c *ClusterMeta) Destroy() error {
 		return err
 	}
 
-	ui.Println(ui.INFO, "Cleaning up cluster directory...", c.Name)
+	ui.Println(ui.INFO, "Cleaning up cluster directory...")
 	if err := os.RemoveAll(c.Path); err != nil {
 		return fmt.Errorf("failed to remove directory of the cluster '%s': %v", c.Name, err)
 	}
+
+	ui.Println(ui.INFO, "Cleaning up cluster cache...")
+	os.RemoveAll(c.CacheDir())
 
 	ui.Printf(ui.INFO, "Cluster '%s' has been successfully destroyed.\n", c.Name)
 	return nil

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -111,6 +111,8 @@ func (c *Cluster) Sync() error {
 	return nil
 }
 
+// Executor returns an executor instance that is responsible for configuring
+// cluster nodes provisioned by the provisioner.
 func (c *Cluster) Executor() executors.Executor {
 	if c.exec != nil {
 		return c.exec
@@ -125,6 +127,7 @@ func (c *Cluster) Executor() executors.Executor {
 		c.Path,
 		c.PrivateSshKeyPath(),
 		c.ConfigDir(),
+		c.CacheDir(),
 		c.ShareDir(),
 		c.NewConfig,
 		c.InfraConfig,
@@ -134,6 +137,9 @@ func (c *Cluster) Executor() executors.Executor {
 	return c.exec
 }
 
+// Provisioner function returns a provisioner instance that is responsible
+// for provisioning virtual infrastructure based on the configuration file
+// provided as input.
 func (c *Cluster) Provisioner() provisioner.Provisioner {
 	if c.prov != nil {
 		return c.prov

--- a/pkg/cluster/executors/kubespray/kubespray.go
+++ b/pkg/cluster/executors/kubespray/kubespray.go
@@ -21,6 +21,7 @@ type kubespray struct {
 	ClusterPath       string
 	SshPrivateKeyPath string
 	ConfigDir         string
+	CacheDir          string
 	SharedDir         string
 	Config            *config.Config
 	InfraConfig       *infra.Config
@@ -45,6 +46,7 @@ func NewKubesprayExecutor(
 	clusterPath string,
 	sshPrivateKeyPath string,
 	configDir string,
+	cacheDir string,
 	sharedDir string,
 	cfg *config.Config,
 	infraCfg *infra.Config,
@@ -55,6 +57,7 @@ func NewKubesprayExecutor(
 		ClusterPath:       clusterPath,
 		SshPrivateKeyPath: sshPrivateKeyPath,
 		ConfigDir:         configDir,
+		CacheDir:          cacheDir,
 		SharedDir:         sharedDir,
 		Config:            cfg,
 		InfraConfig:       infraCfg,
@@ -84,7 +87,7 @@ func (e *kubespray) Init() error {
 
 	if e.Ansible == nil {
 		ansibleBinDir := path.Join(e.VirtualEnv.Path(), "bin")
-		e.Ansible = ansible.NewAnsible(ansibleBinDir)
+		e.Ansible = ansible.NewAnsible(ansibleBinDir, e.CacheDir)
 	}
 
 	return e.KubitectHostsSetup()

--- a/pkg/cluster/executors/kubespray/kubespray_test.go
+++ b/pkg/cluster/executors/kubespray/kubespray_test.go
@@ -80,6 +80,7 @@ func TestNewExecutor(t *testing.T) {
 		path.Join(tmpDir, clsName),
 		path.Join(tmpDir, "id_rsa"),
 		path.Join(tmpDir, "config"),
+		path.Join(tmpDir, "cache"),
 		path.Join(tmpDir, "share"),
 		&config.Config{},
 		&infra.Config{},

--- a/pkg/cluster/meta.go
+++ b/pkg/cluster/meta.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	DefaultConfigDir    = "config"
-	DefaultShareDir     = "share"
+	DefaultCacheDir     = "cache"
 	DefaultTerraformDir = DefaultConfigDir + "/terraform"
 
 	DefaultNewConfigFilename     = "kubitect.yaml"
@@ -36,6 +36,15 @@ type ClusterMeta struct {
 
 func (c ClusterMeta) ConfigDir() string {
 	return filepath.Join(c.Path, DefaultConfigDir)
+}
+
+func (c ClusterMeta) CacheDir() string {
+	clustersDir := c.ClustersDir()
+	if c.Local {
+		clustersDir = c.LocalClustersDir()
+	}
+	cacheDir := filepath.Join(clustersDir, "..", DefaultCacheDir, c.Name)
+	return filepath.Clean(cacheDir)
 }
 
 func (c ClusterMeta) AppliedConfigPath() string {

--- a/pkg/cluster/provisioner/terraform/cmd_default.go
+++ b/pkg/cluster/provisioner/terraform/cmd_default.go
@@ -27,6 +27,7 @@ func (t *terraform) runCmd(action string, args []string, showOutput bool) (int, 
 		cmd.Stdout = ui.Streams().Out().File()
 	}
 
+	cmd.Env = []string{fmt.Sprintf("PATH=%s", os.Getenv("PATH"))}
 	if ui.Debug() {
 		cmd.Env = append(cmd.Env, "TF_LOG=INFO")
 	}

--- a/pkg/cluster/provisioner/terraform/cmd_default.go
+++ b/pkg/cluster/provisioner/terraform/cmd_default.go
@@ -5,6 +5,7 @@ package terraform
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/MusicDin/kubitect/pkg/ui"

--- a/pkg/cluster/provisioner/terraform/cmd_linux.go
+++ b/pkg/cluster/provisioner/terraform/cmd_linux.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
 
@@ -29,6 +30,7 @@ func (t *terraform) runCmd(action string, args []string, showOutput bool) (int, 
 		cmd.Stdout = ui.Streams().Out().File()
 	}
 
+	cmd.Env = []string{fmt.Sprintf("PATH=%s", os.Getenv("PATH"))}
 	if ui.Debug() {
 		cmd.Env = append(cmd.Env, "TF_LOG=INFO")
 	}

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -35,18 +35,46 @@ var ProjectApplyActions = [...]string{
 	"scale",
 }
 
-var ProjectOsPresets = map[string]string{
-	"ubuntu":   "https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img",
-	"ubuntu22": "https://cloud-images.ubuntu.com/releases/jammy/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img",
-	"ubuntu20": "https://cloud-images.ubuntu.com/releases/focal/release-20230209/ubuntu-20.04-server-cloudimg-amd64.img",
-	"debian":   "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-amd64.qcow2",
-	"debian11": "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-genericcloud-amd64-20230124-1270.qcow2",
-	"centos9":  "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230405.1.x86_64.qcow2",
-	"rocky":    "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2",
-}
-
 var ProjectK8sVersions = []string{
 	"v1.23",
 	"v1.24",
 	"v1.25",
+}
+
+var ProjectOsPresets = map[string]struct {
+	Source           string
+	NetworkInterface string
+}{
+	"ubuntu": {
+		Source:           "https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img",
+		NetworkInterface: "ens3",
+	},
+	"ubuntu22": {
+		Source:           "https://cloud-images.ubuntu.com/releases/jammy/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img",
+		NetworkInterface: "ens3",
+	},
+	"ubuntu20": {
+		Source:           "https://cloud-images.ubuntu.com/releases/focal/release-20230209/ubuntu-20.04-server-cloudimg-amd64.img",
+		NetworkInterface: "ens3",
+	},
+	"debian": {
+		Source:           "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-amd64.qcow2",
+		NetworkInterface: "ens3",
+	},
+	"debian11": {
+		Source:           "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-genericcloud-amd64-20230124-1270.qcow2",
+		NetworkInterface: "ens3",
+	},
+	"centos9": {
+		Source:           "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230405.1.x86_64.qcow2",
+		NetworkInterface: "eth0",
+	},
+	"rocky": {
+		Source:           "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2",
+		NetworkInterface: "eth0",
+	},
+	"rocky9": {
+		Source:           "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.1-20230215.0.x86_64.qcow2",
+		NetworkInterface: "eth0",
+	},
 }

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -41,6 +41,7 @@ var ProjectOsPresets = map[string]string{
 	"ubuntu20": "https://cloud-images.ubuntu.com/releases/focal/release-20230209/ubuntu-20.04-server-cloudimg-amd64.img",
 	"debian":   "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-amd64.qcow2",
 	"debian11": "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-genericcloud-amd64-20230124-1270.qcow2",
+	"centos9":  "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230405.1.x86_64.qcow2",
 }
 
 var ProjectK8sVersions = []string{

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -42,6 +42,7 @@ var ProjectOsPresets = map[string]string{
 	"debian":   "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-amd64.qcow2",
 	"debian11": "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-genericcloud-amd64-20230124-1270.qcow2",
 	"centos9":  "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230405.1.x86_64.qcow2",
+	"rocky":    "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2",
 }
 
 var ProjectK8sVersions = []string{

--- a/pkg/models/config/cluster_node_template.go
+++ b/pkg/models/config/cluster_node_template.go
@@ -62,10 +62,11 @@ const (
 	DEBIAN   OSDistro = "debian"
 	DEBIAN11 OSDistro = "debian11"
 	CENTOS9  OSDistro = "centos9"
+	ROCKY    OSDistro = "rocky"
 )
 
 func (d OSDistro) Validate() error {
-	return v.Var(d, v.OneOf(UBUNTU, UBUNTU20, UBUNTU22, DEBIAN, DEBIAN11, CENTOS9))
+	return v.Var(d, v.OneOf(UBUNTU, UBUNTU20, UBUNTU22, DEBIAN, DEBIAN11, CENTOS9, ROCKY))
 }
 
 type OSNetworkInterface string

--- a/pkg/models/config/cluster_node_template.go
+++ b/pkg/models/config/cluster_node_template.go
@@ -48,9 +48,11 @@ func (s OS) Validate() error {
 }
 
 func (s *OS) SetDefaults() {
-	s.NetworkInterface = defaults.Default(s.NetworkInterface, OSNetworkInterface("ens3"))
 	s.Distro = defaults.Default(s.Distro, UBUNTU)
-	s.Source = defaults.Default(s.Source, OSSource(env.ProjectOsPresets[string(s.Distro)]))
+
+	preset := env.ProjectOsPresets[string(s.Distro)]
+	s.NetworkInterface = defaults.Default(s.NetworkInterface, OSNetworkInterface(preset.NetworkInterface))
+	s.Source = defaults.Default(s.Source, OSSource(preset.Source))
 }
 
 type OSDistro string
@@ -63,10 +65,11 @@ const (
 	DEBIAN11 OSDistro = "debian11"
 	CENTOS9  OSDistro = "centos9"
 	ROCKY    OSDistro = "rocky"
+	ROCKY9   OSDistro = "rocky9"
 )
 
 func (d OSDistro) Validate() error {
-	return v.Var(d, v.OneOf(UBUNTU, UBUNTU20, UBUNTU22, DEBIAN, DEBIAN11, CENTOS9, ROCKY))
+	return v.Var(d, v.OneOf(UBUNTU, UBUNTU20, UBUNTU22, DEBIAN, DEBIAN11, CENTOS9, ROCKY, ROCKY9))
 }
 
 type OSNetworkInterface string

--- a/pkg/models/config/cluster_node_template.go
+++ b/pkg/models/config/cluster_node_template.go
@@ -59,10 +59,11 @@ const (
 	UBUNTU22 OSDistro = "ubuntu22"
 	DEBIAN   OSDistro = "debian"
 	DEBIAN11 OSDistro = "debian11"
+	CENTOS9  OSDistro = "centos9"
 )
 
 func (d OSDistro) Validate() error {
-	return v.Var(d, v.OneOf(UBUNTU, UBUNTU20, UBUNTU22, DEBIAN, DEBIAN11))
+	return v.Var(d, v.OneOf(UBUNTU, UBUNTU20, UBUNTU22, DEBIAN, DEBIAN11, CENTOS9))
 }
 
 type OSNetworkInterface string

--- a/pkg/models/config/cluster_node_template_test.go
+++ b/pkg/models/config/cluster_node_template_test.go
@@ -30,7 +30,7 @@ func TestOSNetworkInterface(t *testing.T) {
 }
 
 func TestOS_Empty(t *testing.T) {
-	assert.ErrorContains(t, OS{}.Validate(), "Field 'distro' must be one of the following values: [ubuntu|ubuntu20|ubuntu22|debian|debian11]")
+	assert.ErrorContains(t, OS{}.Validate(), "Field 'distro' must be one of the following values: [ubuntu|ubuntu20|ubuntu22|debian|debian11|centos9|rocky]")
 	assert.ErrorContains(t, OS{}.Validate(), "Field 'networkInterface' can contain only alphanumeric characters.")
 }
 

--- a/pkg/models/config/cluster_node_template_test.go
+++ b/pkg/models/config/cluster_node_template_test.go
@@ -19,7 +19,7 @@ func TestOSDistro(t *testing.T) {
 func TestOSDistro_Presets(t *testing.T) {
 	for k, v := range env.ProjectOsPresets {
 		assert.NoErrorf(t, OSDistro(k).Validate(), "OS preset %s represents an unknown OS distro", k)
-		assert.NoErrorf(t, URL(v).Validate(), "%s preset URL (%s) is invalid!", k, v)
+		assert.NoErrorf(t, URL(v.Source).Validate(), "%s preset URL (%s) is invalid!", k, v)
 	}
 }
 
@@ -30,24 +30,29 @@ func TestOSNetworkInterface(t *testing.T) {
 }
 
 func TestOS_Empty(t *testing.T) {
-	assert.ErrorContains(t, OS{}.Validate(), "Field 'distro' must be one of the following values: [ubuntu|ubuntu20|ubuntu22|debian|debian11|centos9|rocky]")
+	assert.ErrorContains(t, OS{}.Validate(), "Field 'distro' must be one of the following values: [ubuntu|")
 	assert.ErrorContains(t, OS{}.Validate(), "Field 'networkInterface' can contain only alphanumeric characters.")
 }
 
 func TestOS_Defaults(t *testing.T) {
 	os1 := OS{Distro: UBUNTU}
-	os2 := OS{Source: OSSource("./cluster_node_template_test.go")}
+	os2 := OS{Distro: ROCKY}
+	os3 := OS{Source: OSSource("./cluster_node_template_test.go")}
 
 	assert.NoError(t, defaults.Assign(&OS{}).Validate())
 	assert.NoError(t, defaults.Assign(&os1).Validate())
 	assert.NoError(t, defaults.Assign(&os2).Validate())
+	assert.NoError(t, defaults.Assign(&os3).Validate())
 
 	assert.Equal(t, UBUNTU, os1.Distro)
-	assert.Equal(t, UBUNTU, os2.Distro)
+	assert.Equal(t, ROCKY, os2.Distro)
+	assert.Equal(t, UBUNTU, os3.Distro)
 	assert.Equal(t, "ens3", string(os1.NetworkInterface))
-	assert.Equal(t, "ens3", string(os2.NetworkInterface))
-	assert.Equal(t, env.ProjectOsPresets["ubuntu"], string(os1.Source))
-	assert.Equal(t, "./cluster_node_template_test.go", string(os2.Source))
+	assert.Equal(t, "eth0", string(os2.NetworkInterface))
+	assert.Equal(t, "ens3", string(os3.NetworkInterface))
+	assert.Equal(t, env.ProjectOsPresets["ubuntu"].Source, string(os1.Source))
+	assert.Equal(t, env.ProjectOsPresets["rocky"].Source, string(os2.Source))
+	assert.Equal(t, "./cluster_node_template_test.go", string(os3.Source))
 }
 
 func TestNodeTemplateSSH(t *testing.T) {

--- a/pkg/tools/ansible/ansible.go
+++ b/pkg/tools/ansible/ansible.go
@@ -109,6 +109,8 @@ func (a *ansible) Exec(pb Playbook) error {
 
 	if ui.Debug() {
 		options.AnsibleSetEnv("ANSIBLE_VERBOSITY", "2")
+	} else {
+		options.AnsibleSetEnv("ANSIBLE_ACTION_WARNINGS", "false")
 	}
 
 	options.AnsibleSetEnv("ANSIBLE_CALLBACKS_ENABLED", "yaml")

--- a/pkg/tools/ansible/ansible.go
+++ b/pkg/tools/ansible/ansible.go
@@ -32,13 +32,15 @@ type (
 	}
 
 	ansible struct {
-		binPath string
+		binPath  string
+		cacheDir string
 	}
 )
 
-func NewAnsible(binDir string) Ansible {
+func NewAnsible(binDir, cacheDir string) Ansible {
 	return &ansible{
-		binPath: path.Join(binDir, "ansible-playbook"),
+		binPath:  path.Join(binDir, "ansible-playbook"),
+		cacheDir: cacheDir,
 	}
 }
 
@@ -73,6 +75,7 @@ func (a *ansible) Exec(pb Playbook) error {
 	playbookOptions := &playbook.AnsiblePlaybookOptions{
 		Inventory: pb.Inventory,
 		Tags:      strings.Join(pb.Tags, ","),
+		Forks:     "50",
 	}
 
 	vars, err := extraVarsToMap(pb.ExtraVars)
@@ -110,15 +113,18 @@ func (a *ansible) Exec(pb Playbook) error {
 	if ui.Debug() {
 		options.AnsibleSetEnv("ANSIBLE_VERBOSITY", "2")
 	} else {
-		options.AnsibleSetEnv("ANSIBLE_ACTION_WARNINGS", "false")
+		options.AnsibleSetEnv("ANSIBLE_LOCALHOST_WARNING", "false")
+		options.AnsibleSetEnv("ANSIBLE_INVENTORY_UNPARSED_WARNING", "false")
 	}
+
+	options.AnsibleSetEnv("ANSIBLE_CACHE_PLUGIN", "jsonfile")
+	options.AnsibleSetEnv("ANSIBLE_CACHE_PLUGIN_CONNECTION", a.cacheDir)
+	options.AnsibleSetEnv("ANSIBLE_CACHE_PLUGIN_TIMEOUT", "86400")
 
 	options.AnsibleSetEnv("ANSIBLE_CALLBACKS_ENABLED", "yaml")
 	options.AnsibleSetEnv("ANSIBLE_HOST_PATTERN_MISMATCH", "ignore")
 	options.AnsibleSetEnv("ANSIBLE_DISPLAY_FAILED_STDERR", "true")
 	options.AnsibleSetEnv("ANSIBLE_DISPLAY_SKIPPED_HOSTS", "false")
-	options.AnsibleSetEnv("ANSIBLE_DISPLAY_ARGS_TO_STDOUT", "false")
-	options.AnsibleSetEnv("ANSIBLE_FORKS", "10")
 	options.AnsibleSetEnv("ANSIBLE_STDOUT_CALLBACK", "yaml")
 	options.AnsibleSetEnv("ANSIBLE_STDERR_CALLBACK", "yaml")
 

--- a/pkg/tools/ansible/ansible_test.go
+++ b/pkg/tools/ansible/ansible_test.go
@@ -34,14 +34,14 @@ func TestExtraVarsToMap_Invalid(t *testing.T) {
 }
 
 func TestAnsible_InvalidPath(t *testing.T) {
-	a := NewAnsible(t.TempDir())
+	a := NewAnsible(t.TempDir(), "")
 
 	pb := Playbook{}
 	assert.EqualError(t, a.Exec(pb), "ansible-playbook: playbook path not set")
 }
 
 func TestAnsible_InvalidInventory(t *testing.T) {
-	a := NewAnsible(t.TempDir())
+	a := NewAnsible(t.TempDir(), "")
 
 	pb := Playbook{
 		Path: "pb.yaml",
@@ -51,7 +51,7 @@ func TestAnsible_InvalidInventory(t *testing.T) {
 }
 
 func TestAnsible_InvalidExtraVar(t *testing.T) {
-	a := NewAnsible(t.TempDir())
+	a := NewAnsible(t.TempDir(), "")
 
 	pb := Playbook{
 		Path:      "pb.yaml",
@@ -63,7 +63,7 @@ func TestAnsible_InvalidExtraVar(t *testing.T) {
 }
 
 func TestAnsible_InvalidBinPath(t *testing.T) {
-	a := NewAnsible(t.TempDir())
+	a := NewAnsible(t.TempDir(), "")
 
 	pb := Playbook{
 		Path:      "pb.yaml",
@@ -74,7 +74,7 @@ func TestAnsible_InvalidBinPath(t *testing.T) {
 }
 
 func TestAnsible_InvalidBinPath2(t *testing.T) {
-	a := NewAnsible(t.TempDir())
+	a := NewAnsible(t.TempDir(), "")
 
 	ui.MockGlobalUi(t, ui.UiOptions{Debug: true, NoColor: true})
 


### PR DESCRIPTION
Add support for RHEL based distros:
- [x] CentOS Stream 9
- [x] Rocky 9

TBD:
- [x] Ansible cache may affect the creation of a new cluster with a different distribution (but the same name), so it is important to ensure that the cache properly handled after destroying the cluster.
- [x] HAProxy Ansible role has to be updated to support these new distributions.
- [x] Rocky Linux can be inconsistent when no static IP is set, as IPv4 is not always returned after provisioning.
- [x] Update docs to reflect the changes