### PR TITLE
Fix addToKnownHosts and updateOnBoot always true

### DIFF
--- a/docs/user-guide/configuration/cluster-node-template.md
+++ b/docs/user-guide/configuration/cluster-node-template.md
@@ -142,6 +142,21 @@ For a more detailed explanation of the available CPU modes and their usage, plea
     The `host-model` and `host-passthrough` modes makes sense only when a virtual machine can run directly on the host CPUs (e.g. virtual machines of type *kvm*).
     The actual host CPU is irrelevant for virtual machines with emulated virtual CPUs (e.g. virtul machines of type *qemu*).
 
+### Update on boot
+
+:material-tag-arrow-up-outline: [v2.2.0][tag 2.2.0]
+&ensp;
+:octicons-file-symlink-file-24: Default: `true`
+
+By default, Kubitect updates all virtual machine packages on boot.
+To disable this behavior, set `updateOnBoot` to false.
+
+```yaml
+cluster:
+  nodeTemplate:
+    updateOnBoot: false
+```
+
 ### SSH options
 
 #### Custom SSH certificate

--- a/docs/user-guide/reference/configuration.md
+++ b/docs/user-guide/reference/configuration.md
@@ -681,7 +681,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
     <tr>
       <td><code>cluster.nodeTemplate.ssh.addToKnownHosts</code></td>
       <td>boolean</td>
-      <td>true</td>
+      <td>false</td>
       <td></td>
       <td>
         If set to true, each virtual machine will be added to the known hosts on the machine where the project is being run.

--- a/pkg/models/config/cluster_node_template.go
+++ b/pkg/models/config/cluster_node_template.go
@@ -12,7 +12,7 @@ type NodeTemplate struct {
 	SSH          NodeTemplateSSH `yaml:"ssh"`
 	CpuMode      CpuMode         `yaml:"cpuMode,omitempty"`
 	DNS          []IP            `yaml:"dns,omitempty"`
-	UpdateOnBoot bool            `yaml:"updateOnBoot"`
+	UpdateOnBoot *bool           `yaml:"updateOnBoot"`
 }
 
 func (n NodeTemplate) Validate() error {
@@ -26,8 +26,11 @@ func (n NodeTemplate) Validate() error {
 }
 
 func (n *NodeTemplate) SetDefaults() {
+	def := true
+
 	n.User = defaults.Default(n.User, "k8s")
 	n.CpuMode = defaults.Default(n.CpuMode, CUSTOM)
+	n.UpdateOnBoot = defaults.Default(n.UpdateOnBoot, &def)
 }
 
 type OS struct {

--- a/pkg/models/config/cluster_node_template.go
+++ b/pkg/models/config/cluster_node_template.go
@@ -9,7 +9,7 @@ import (
 type NodeTemplate struct {
 	User         User            `yaml:"user"`
 	OS           OS              `yaml:"os"`
-	SSH          NodeTemplateSSH `yaml:"ssh,omitempty"`
+	SSH          NodeTemplateSSH `yaml:"ssh"`
 	CpuMode      CpuMode         `yaml:"cpuMode,omitempty"`
 	DNS          []IP            `yaml:"dns,omitempty"`
 	UpdateOnBoot bool            `yaml:"updateOnBoot"`
@@ -28,7 +28,6 @@ func (n NodeTemplate) Validate() error {
 func (n *NodeTemplate) SetDefaults() {
 	n.User = defaults.Default(n.User, "k8s")
 	n.CpuMode = defaults.Default(n.CpuMode, CUSTOM)
-	n.UpdateOnBoot = defaults.Default(n.UpdateOnBoot, true)
 }
 
 type OS struct {
@@ -79,16 +78,12 @@ func (os OSSource) Validate() error {
 
 type NodeTemplateSSH struct {
 	AddToKnownHosts bool `yaml:"addToKnownHosts"`
-	PrivateKeyPath  File `yaml:"privateKeyPath"`
+	PrivateKeyPath  File `yaml:"privateKeyPath,omitempty"`
 }
 
 func (ssh NodeTemplateSSH) Validate() error {
 	return v.Struct(&ssh)
 	// v.Field(&ssh.PrivateKeyPath, v.Skip()),
-}
-
-func (ssh *NodeTemplateSSH) SetDefaults() {
-	ssh.AddToKnownHosts = defaults.Default(ssh.AddToKnownHosts, true)
 }
 
 type CpuMode string


### PR DESCRIPTION
Properties `addToKnownHosts` and `updateOnBoot` were always evaluated to true.
In addition, add missing docs for `updateOnBoot` property.