### PR TITLE
Validate LB forward port number and name are unique

### DIFF
--- a/pkg/models/config/cluster_nodes_lb.go
+++ b/pkg/models/config/cluster_nodes_lb.go
@@ -48,7 +48,7 @@ func (lb LB) Validate() error {
 		v.Field(&lb.VirtualRouterId),
 		v.Field(&lb.Default),
 		v.Field(&lb.Instances, v.UniqueField("Id")),
-		v.Field(&lb.ForwardPorts),
+		v.Field(&lb.ForwardPorts, v.UniqueField("Name"), v.UniqueField("Port")),
 	)
 }
 

--- a/pkg/models/config/cluster_nodes_lb_test.go
+++ b/pkg/models/config/cluster_nodes_lb_test.go
@@ -133,3 +133,25 @@ func TestLB_MissingVIP(t *testing.T) {
 
 	assert.EqualError(t, defaults.Assign(&lb).Validate(), "Virtual IP (VIP) is required when multiple load balancer instances are configured.")
 }
+
+func TestLB_PortForward_UniqueName(t *testing.T) {
+	lb := LB{
+		ForwardPorts: []LBPortForward{
+			{Name: "http"},
+			{Name: "http"},
+		},
+	}
+
+	assert.EqualError(t, defaults.Assign(&lb).Validate(), "Field 'Name' must be unique for each element in 'forwardPorts'.")
+}
+
+func TestLB_PortForward_UniquePort(t *testing.T) {
+	lb := LB{
+		ForwardPorts: []LBPortForward{
+			{Name: "http", Port: 80},
+			{Name: "https", Port: 80},
+		},
+	}
+
+	assert.EqualError(t, defaults.Assign(&lb).Validate(), "Field 'Port' must be unique for each element in 'forwardPorts'.")
+}


### PR DESCRIPTION
Add validation for load balancer forward ports - name and incoming port number must be unique.