### PR TITLE
Fix unmarshal error when Kubespray addons are configured

### DIFF
--- a/pkg/cluster/executors/kubespray/kubespray.go
+++ b/pkg/cluster/executors/kubespray/kubespray.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MusicDin/kubitect/pkg/tools/git"
 	"github.com/MusicDin/kubitect/pkg/tools/virtualenv"
 	"github.com/MusicDin/kubitect/pkg/ui"
+	"gopkg.in/yaml.v3"
 )
 
 type kubespray struct {
@@ -217,7 +218,12 @@ func (e *kubespray) generateGroupVars() error {
 		return err
 	}
 
-	err = NewKubesprayAddonsTemplate(e.ConfigDir, e.Config.Addons.Kubespray).Write()
+	addons, err := yaml.Marshal(e.Config.Addons.Kubespray)
+	if err != nil {
+		return err
+	}
+
+	err = NewKubesprayAddonsTemplate(e.ConfigDir, string(addons)).Write()
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/executors/kubespray/template_test.go
+++ b/pkg/cluster/executors/kubespray/template_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/MusicDin/kubitect/pkg/models/config"
 	"github.com/MusicDin/kubitect/pkg/utils/template"
+	"gopkg.in/yaml.v3"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKubesprayAllTemplate(t *testing.T) {
@@ -37,12 +39,19 @@ func TestKubesprayK8sClusterTemplate(t *testing.T) {
 }
 
 func TestKubesprayAddonsTemplate(t *testing.T) {
-	tpl := NewKubesprayAddonsTemplate(t.TempDir(), "test: test")
+	addons := map[string]any{
+		"test": "test",
+	}
+
+	bytes, err := yaml.Marshal(addons)
+	require.NoError(t, err)
+
+	tpl := NewKubesprayAddonsTemplate(t.TempDir(), string(bytes))
 	pop, err := template.Populate(tpl)
 
-	assert.NoError(t, err)
-	assert.NoError(t, tpl.Write())
-	assert.Equal(t, pop, "test: test")
+	require.NoError(t, err)
+	require.NoError(t, tpl.Write())
+	assert.Equal(t, "test: test\n", pop)
 }
 
 func TestKubesprayEtcdTemplate(t *testing.T) {

--- a/pkg/models/config/addons.go
+++ b/pkg/models/config/addons.go
@@ -3,8 +3,8 @@ package config
 import v "github.com/MusicDin/kubitect/pkg/utils/validation"
 
 type Addons struct {
-	Kubespray string `yaml:"kubespray,omitempty" opt:"-"`
-	Rook      Rook   `yaml:"rook,omitempty"`
+	Kubespray map[string]any `yaml:"kubespray,omitempty" opt:"-"`
+	Rook      Rook           `yaml:"rook,omitempty"`
 }
 
 func (a Addons) Validate() error {


### PR DESCRIPTION
Change `config.kubespray.addons` type to map to prevent an unmarshal error when Kubespray addons are configured.