### PR TITLE
Increase Kubespray version to v2.22.0

### DIFF
--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -9,7 +9,7 @@ const (
 	ConstProjectUrl        = "https://github.com/MusicDin/kubitect"
 	ConstProjectVersion    = "v3.1.0"
 	ConstKubesprayUrl      = "https://github.com/kubernetes-sigs/kubespray"
-	ConstKubesprayVersion  = "v2.21.0"
+	ConstKubesprayVersion  = "v2.22.0"
 	ConstKubernetesVersion = "v1.25.6"
 	ConstTerraformVersion  = "1.4.4"
 )
@@ -36,9 +36,9 @@ var ProjectApplyActions = [...]string{
 }
 
 var ProjectK8sVersions = []string{
-	"v1.23",
 	"v1.24",
 	"v1.25",
+	"v1.26",
 }
 
 var ProjectOsPresets = map[string]struct {

--- a/pkg/models/config/kubernetes_test.go
+++ b/pkg/models/config/kubernetes_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestKubernetesVersion(t *testing.T) {
-	assert.NoError(t, KubernetesVersion("v1.23.0").Validate())
-	assert.NoError(t, KubernetesVersion("v1.23.10").Validate())
 	assert.NoError(t, KubernetesVersion("v1.24.0").Validate())
 	assert.NoError(t, KubernetesVersion("v1.24.10").Validate())
 	assert.NoError(t, KubernetesVersion("v1.25.0").Validate())
 	assert.NoError(t, KubernetesVersion("v1.25.10").Validate())
+	assert.NoError(t, KubernetesVersion("v1.26.0").Validate())
+	assert.NoError(t, KubernetesVersion("v1.26.10").Validate())
 	assert.ErrorContains(t, KubernetesVersion("v1.26.").Validate(), "Unsupported Kubernetes version")
 	assert.ErrorContains(t, KubernetesVersion("v1.26.100").Validate(), "Unsupported Kubernetes version")
 }


### PR DESCRIPTION
Bump Kubespray version to `v2.21.0` -> `v2.22.0`

In addition, allowed Kubernetes versions are updated to: [`1.24`, `1.25`, `1.26`]