### PR TITLE
Rely on QEMU guest agent only in bridge network mode

### DIFF
--- a/embed/terraform/modules/vm/vm.tf
+++ b/embed/terraform/modules/vm/vm.tf
@@ -83,7 +83,7 @@ resource "libvirt_domain" "vm_domain" {
 
   cloudinit = libvirt_cloudinit_disk.cloud_init.id
 
-  qemu_agent = true
+  qemu_agent = (var.network_mode == "bridge")
 
   # Network configuration #
   network_interface {


### PR DESCRIPTION
When network mode is set to `nat`, IP addresses can be queried from the local network instead of relying on the QEMU guest agent.