### PR TITLE
Skip local clusters search if local and global paths match

### DIFF
--- a/pkg/cmd/meta_clusters.go
+++ b/pkg/cmd/meta_clusters.go
@@ -65,6 +65,12 @@ func clusters(ctx app.AppContext, local bool) (MetaClusters, error) {
 	var path string
 
 	if local {
+		// Ignore local clusters if the local and global cluster directory
+		// paths are the same.
+		if ctx.LocalClustersDir() == ctx.ClustersDir() {
+			return nil, nil
+		}
+
 		path = ctx.LocalClustersDir()
 	} else {
 		path = ctx.ClustersDir()


### PR DESCRIPTION
When the directory path of local clusters is identical to the path of the global clusters directory, certain operations (e.g. `export`) may be broken due to the detection of multiple clusters sharing the same name.