### PR TITLE
Fix local cluster search causes duplicate names

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -69,7 +69,7 @@ Verify the installation by checking the Kubitect version.
 ```sh
 kubitect --version
 
-# kubitect version v3.1.0
+# kubitect version v3.1.1
 ```
 
 ## Enable shell autocomplete

--- a/pkg/cmd/meta_clusters.go
+++ b/pkg/cmd/meta_clusters.go
@@ -65,6 +65,12 @@ func clusters(ctx app.AppContext, local bool) (MetaClusters, error) {
 	var path string
 
 	if local {
+		// Ignore local clusters if the local and global cluster directory
+		// paths are the same.
+		if ctx.LocalClustersDir() == ctx.ClustersDir() {
+			return nil, nil
+		}
+
 		path = ctx.LocalClustersDir()
 	} else {
 		path = ctx.ClustersDir()

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -7,7 +7,7 @@ package env
 // Project related constants
 const (
 	ConstProjectUrl        = "https://github.com/MusicDin/kubitect"
-	ConstProjectVersion    = "v3.1.0"
+	ConstProjectVersion    = "v3.1.1"
 	ConstKubesprayUrl      = "https://github.com/kubernetes-sigs/kubespray"
 	ConstKubesprayVersion  = "v2.21.0"
 	ConstKubernetesVersion = "v1.25.6"


### PR DESCRIPTION
When the directory path of local clusters is identical to the path of the global clusters directory, certain operations (e.g. `export`) may be broken due to the detection of multiple clusters sharing the same name.