### PR TITLE
Add latest CentOS Stream 9

### DIFF
--- a/docs/user-guide/configuration/cluster-node-template.md
+++ b/docs/user-guide/configuration/cluster-node-template.md
@@ -57,7 +57,7 @@ cluster:
 The available operating system distribution presets are:
 
 + **`ubuntu`** - Latest Ubuntu 22.04 release. (default)
-+ `ubuntu22` - Ubuntu 22.04 release as of *2023-06-08*.
++ `ubuntu22` - Ubuntu 22.04 release as of *2023-06-06*.
 + `ubuntu20` - Ubuntu 20.04 release as of *2023-06-06*.
 + **`debian`** - Latest Debian 11 release.
 + `debian11` - Debian 11 release as of *2023-06-01*.

--- a/docs/user-guide/configuration/cluster-node-template.md
+++ b/docs/user-guide/configuration/cluster-node-template.md
@@ -20,9 +20,9 @@ This includes the properties of the operating system (OS), DNS, and the virtual 
 &ensp;
 :octicons-file-symlink-file-24: Default: `k8s`
 
-The user property defines the name of the user created on each virtual machine. 
-This user is used to access the virtual machines during cluster configuration. 
-If you omit the user property, a user named `k8s` is created on all virtual machines. 
+The user property defines the name of the user created on each virtual machine.
+This user is used to access the virtual machines during cluster configuration.
+If you omit the user property, a user named `k8s` is created on all virtual machines.
 You can also use this user later to access each virtual machine via SSH.
 
 ```yaml
@@ -39,7 +39,7 @@ cluster:
 &ensp;
 :octicons-file-symlink-file-24: Default: `ubuntu`
 
-The operating system for virtual machines can be specified in the node template. 
+The operating system for virtual machines can be specified in the node template.
 By default, the Ubuntu distribution is installed on all virtual machines.
 
 You can select a desired distribution by setting the `os.distro` property.
@@ -57,13 +57,14 @@ cluster:
 The available operating system distribution presets are:
 
 + **`ubuntu`** - Latest Ubuntu 22.04 release. (default)
-+ `ubuntu22` - Ubuntu 22.04 release as of *2023-03-02*.
-+ `ubuntu20` - Ubuntu 20.04 release as of *2023-02-09*.
++ `ubuntu22` - Ubuntu 22.04 release as of *2023-06-08*.
++ `ubuntu20` - Ubuntu 20.04 release as of *2023-06-06*.
 + **`debian`** - Latest Debian 11 release.
-+ `debian11` - Debian 11 release as of *2023-01-24*.
++ `debian11` - Debian 11 release as of *2023-06-01*.
 + **`rocky`** - Latest Rocky 9 release.
-+ `rocky9` - Rocky 9.1 release as of *2023-02-15*.
-+ **`centos9`** - CentOS Stream 9 release as of *2023-04-05*.
++ `rocky9` - Rocky 9.1 release as of *2023-05-13*.
++ **`centos`** - Latest CentOS Stream 9 release.
++ `centos9` - CentOS Stream 9 release as of *2023-06-05*.
 
 !!! warning "Important"
 
@@ -73,7 +74,7 @@ The available operating system distribution presets are:
 
 !!! danger "Known issues"
 
-    **CentOS Stream** images already include the `qemu-guest-agent` package, which reports IP addresses of the virtual machines before they are leased from a DHCP server. 
+    **CentOS Stream** images already include the `qemu-guest-agent` package, which reports IP addresses of the virtual machines before they are leased from a DHCP server.
     This can cause issues during infrastructure provisioning if the virtual machines are not configured with static IP addresses.
 
 
@@ -90,7 +91,7 @@ The available operating system distribution presets are:
 
 :material-tag-arrow-up-outline: [v2.1.0][tag 2.1.0]
 
-If the presets do not meet your needs, you can use a custom Ubuntu or Debian image by specifying the image source. 
+If the presets do not meet your needs, you can use a custom Ubuntu or Debian image by specifying the image source.
 The source of an image can be either a local path on your system or a URL pointing to the image download.
 
 ```yaml
@@ -120,7 +121,7 @@ cluster:
 
 :material-tag-arrow-up-outline: [v2.1.0][tag 2.1.0]
 
-The configuration of Domain Name Servers (DNS) in the node template allows for customizing the DNS resolution of all virtual machines in the cluster. 
+The configuration of Domain Name Servers (DNS) in the node template allows for customizing the DNS resolution of all virtual machines in the cluster.
 By default, the DNS list contains only the network gateway.
 
 To add custom DNS servers, specify them using the `dns` property in the node template.
@@ -156,7 +157,7 @@ Currently, there are several CPU modes available:
 - `host-passthrough`
 - `maximum`
 
-In short, the `host-model` mode uses the same CPU model as the host, while the `host-passthrough` mode provides full CPU feature set to the guest virtual machine, but may impact its live migration. 
+In short, the `host-model` mode uses the same CPU model as the host, while the `host-passthrough` mode provides full CPU feature set to the guest virtual machine, but may impact its live migration.
 The `maximum` mode selects the CPU with the most available features.
 For a more detailed explanation of the available CPU modes and their usage, please refer to the [libvirt documentation](https://libvirt.org/formatdomain.html#cpu-model-and-topology).
 
@@ -189,7 +190,7 @@ cluster:
 Kubitect automatically generates SSH certificates before deploying the cluster to ensure secure communication between nodes.
 The generated certificates can be found in the `config/.ssh/` directory inside the cluster directory.
 
-If you prefer to use a custom SSH certificate, you can specify the local path to the private key. 
+If you prefer to use a custom SSH certificate, you can specify the local path to the private key.
 Note that the public key must also be present in the same directory with the `.pub` suffix.
 
 

--- a/docs/user-guide/reference/configuration.md
+++ b/docs/user-guide/reference/configuration.md
@@ -110,7 +110,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
       <td>false</td>
       <td></td>
       <td>
-        Nodes where host is not specified will be installed on default host. 
+        Nodes where host is not specified will be installed on default host.
         The first host in the list is used as a default host if none is marked as a default.
       </td>
     </tr>
@@ -268,7 +268,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
       <td></td>
       <td></td>
       <td>
-        Name of the host on which the instance is deployed. 
+        Name of the host on which the instance is deployed.
         If the name is not specified, the instance is deployed on the default host.
       </td>
     </tr>
@@ -312,7 +312,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
       <td></td>
       <td>
         Keepalived priority of the load balancer.
-        A load balancer with the highest priority becomes the leader (active). 
+        A load balancer with the highest priority becomes the leader (active).
         The priority can be set to any number between 0 and 255.
       </td>
     </tr>
@@ -422,7 +422,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
       <td></td>
       <td></td>
       <td>
-        Name of the host on which the instance is deployed. 
+        Name of the host on which the instance is deployed.
         If the name is not specified, the instance is deployed on the default host.
       </td>
     </tr>
@@ -559,7 +559,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
       <td></td>
       <td></td>
       <td>
-        Name of the host on which the instance is deployed. 
+        Name of the host on which the instance is deployed.
         If the name is not specified, the instance is deployed on the default host.
       </td>
     </tr>
@@ -654,6 +654,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
           <li><code>debian11</code></li>
           <li><code>rocky</code></li>
           <li><code>rocky9</code></li>
+          <li><code>centos</code></li>
           <li><code>centos9</code></li>
         </ul>
       </td>
@@ -675,7 +676,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
       <td>Depends on <code>os.distro</code></td>
       <td></td>
       <td>
-        Source of an OS image. 
+        Source of an OS image.
         It can be either path on a local file system or an URL of the image.
         By default, the value from distro preset (<i>/terraform/defaults.yaml</i>)isset, but can be overwritten if needed.
       </td>
@@ -736,7 +737,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
       <td>coredns</td>
       <td></td>
       <td>
-        DNS server used within a Kubernetes cluster. Possible values are: 
+        DNS server used within a Kubernetes cluster. Possible values are:
         <ul>
           <li><code>coredns</code></li>
         </ul>
@@ -748,7 +749,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
       <td>calico</td>
       <td></td>
       <td>
-        Network plugin used within a Kubernetes cluster. Possible values are: 
+        Network plugin used within a Kubernetes cluster. Possible values are:
         <ul>
           <li><code>calico</code></li>
           <li><code>cilium</code></li>

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -1,4 +1,4 @@
-// The env package provides constants for all other packages to consume,
+// Package env provides constants for all other packages to consume,
 // without creating import cycles.
 //
 // This package should not import any other packages.
@@ -14,33 +14,35 @@ const (
 	ConstTerraformVersion  = "1.4.4"
 )
 
-// Defines applications that Kubitect depends on.
+// ProjectRequiredApps define applications that Kubitect depends on.
 var ProjectRequiredApps = []string{
 	"virtualenv",
 	"python3",
 	"git",
 }
 
-// Defines required files/directories that are copied from embedded
-// resources, when cluster is created.
+// ProjectRequiredFiles define required files/directories that are copied
+// from embedded resources, when cluster is created.
 var ProjectRequiredFiles = []string{
 	"ansible/",
 	"terraform/",
 }
 
-// Defines options for "apply --action" command.
+// ProjectApplyActions define options for "apply --action" command.
 var ProjectApplyActions = [...]string{
 	"create",
 	"upgrade",
 	"scale",
 }
 
+// ProjectK8sVersions define supported Kubernetes versions.
 var ProjectK8sVersions = []string{
 	"v1.24",
 	"v1.25",
 	"v1.26",
 }
 
+// ProjectOsPresets is a list of available OS distros.
 var ProjectOsPresets = map[string]struct {
 	Source           string
 	NetworkInterface string
@@ -50,7 +52,7 @@ var ProjectOsPresets = map[string]struct {
 		NetworkInterface: "ens3",
 	},
 	"ubuntu22": {
-		Source:           "https://cloud-images.ubuntu.com/releases/jammy/release-20230608/ubuntu-22.04-server-cloudimg-amd64.img",
+		Source:           "https://cloud-images.ubuntu.com/releases/jammy/release-20230606/ubuntu-22.04-server-cloudimg-amd64.img",
 		NetworkInterface: "ens3",
 	},
 	"ubuntu20": {

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -50,11 +50,11 @@ var ProjectOsPresets = map[string]struct {
 		NetworkInterface: "ens3",
 	},
 	"ubuntu22": {
-		Source:           "https://cloud-images.ubuntu.com/releases/jammy/release-20230302/ubuntu-22.04-server-cloudimg-amd64.img",
+		Source:           "https://cloud-images.ubuntu.com/releases/jammy/release-20230608/ubuntu-22.04-server-cloudimg-amd64.img",
 		NetworkInterface: "ens3",
 	},
 	"ubuntu20": {
-		Source:           "https://cloud-images.ubuntu.com/releases/focal/release-20230209/ubuntu-20.04-server-cloudimg-amd64.img",
+		Source:           "https://cloud-images.ubuntu.com/releases/focal/release-20230606/ubuntu-20.04-server-cloudimg-amd64.img",
 		NetworkInterface: "ens3",
 	},
 	"debian": {
@@ -62,11 +62,15 @@ var ProjectOsPresets = map[string]struct {
 		NetworkInterface: "ens3",
 	},
 	"debian11": {
-		Source:           "https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-genericcloud-amd64-20230124-1270.qcow2",
+		Source:           "https://cloud.debian.org/images/cloud/bullseye/20230601-1398/debian-11-genericcloud-amd64-20230601-1398.qcow2",
 		NetworkInterface: "ens3",
 	},
+	"centos": {
+		Source:           "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2",
+		NetworkInterface: "eth0",
+	},
 	"centos9": {
-		Source:           "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230405.1.x86_64.qcow2",
+		Source:           "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230605.0.x86_64.qcow2",
 		NetworkInterface: "eth0",
 	},
 	"rocky": {
@@ -74,7 +78,7 @@ var ProjectOsPresets = map[string]struct {
 		NetworkInterface: "eth0",
 	},
 	"rocky9": {
-		Source:           "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.1-20230215.0.x86_64.qcow2",
+		Source:           "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.2-20230513.0.x86_64.qcow2",
 		NetworkInterface: "eth0",
 	},
 }

--- a/pkg/models/config/cluster_node_template.go
+++ b/pkg/models/config/cluster_node_template.go
@@ -63,13 +63,14 @@ const (
 	UBUNTU22 OSDistro = "ubuntu22"
 	DEBIAN   OSDistro = "debian"
 	DEBIAN11 OSDistro = "debian11"
+	CENTOS   OSDistro = "centos"
 	CENTOS9  OSDistro = "centos9"
 	ROCKY    OSDistro = "rocky"
 	ROCKY9   OSDistro = "rocky9"
 )
 
 func (d OSDistro) Validate() error {
-	return v.Var(d, v.OneOf(UBUNTU, UBUNTU20, UBUNTU22, DEBIAN, DEBIAN11, CENTOS9, ROCKY, ROCKY9))
+	return v.Var(d, v.OneOf(UBUNTU, UBUNTU20, UBUNTU22, DEBIAN, DEBIAN11, CENTOS, CENTOS9, ROCKY, ROCKY9))
 }
 
 type OSNetworkInterface string


### PR DESCRIPTION
Add new distro option for latest CentOS Stream 9 release (`centos`) and update existing distro releases.