### PR TITLE
Fix instance address not being registered within the virtual network

### DIFF
--- a/embed/terraform/modules/vm/vm.tf
+++ b/embed/terraform/modules/vm/vm.tf
@@ -90,6 +90,7 @@ resource "libvirt_domain" "vm_domain" {
     network_id     = var.network_id
     mac            = var.vm_mac
     bridge         = var.network_bridge
+    addresses      = var.network_mode == "nat" && var.vm_ip != null ? [var.vm_ip] : null
     wait_for_lease = true
   }
 

--- a/embed/terraform/templates/cloud_init/cloud_init_network_static.tpl
+++ b/embed/terraform/templates/cloud_init/cloud_init_network_static.tpl
@@ -1,7 +1,7 @@
 version: 2
 ethernets:
   ${network_interface}:
-    dhcp4: false
+    dhcp4: true
     dhcp6: false
     addresses: [${vm_cidr}]
     gateway4: ${network_gateway}


### PR DESCRIPTION
Fixes #149

Changes:
- Explicitly register instance address in virtual network when network mode is set to nat
- Enable DHCP even when static IP is set (as fallback) 