### PR TITLE
Improve Kubernetes version validation

### DIFF
--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -37,9 +37,9 @@ var ProjectApplyActions = [...]string{
 
 // ProjectK8sVersions define supported Kubernetes versions.
 var ProjectK8sVersions = []string{
-	"v1.24",
-	"v1.25",
-	"v1.26",
+	"v1.26.0 - v1.26.5",
+	"v1.25.0 - v1.25.10",
+	"v1.24.0 - v1.24.14",
 }
 
 // ProjectOsPresets is a list of available OS distros.

--- a/pkg/models/config/kubernetes_test.go
+++ b/pkg/models/config/kubernetes_test.go
@@ -11,12 +11,12 @@ import (
 
 func TestKubernetesVersion(t *testing.T) {
 	assert.NoError(t, KubernetesVersion("v1.24.0").Validate())
-	assert.NoError(t, KubernetesVersion("v1.24.10").Validate())
+	assert.NoError(t, KubernetesVersion("v1.24.5").Validate())
 	assert.NoError(t, KubernetesVersion("v1.25.0").Validate())
-	assert.NoError(t, KubernetesVersion("v1.25.10").Validate())
+	assert.NoError(t, KubernetesVersion("v1.25.5").Validate())
 	assert.NoError(t, KubernetesVersion("v1.26.0").Validate())
-	assert.NoError(t, KubernetesVersion("v1.26.10").Validate())
-	assert.ErrorContains(t, KubernetesVersion("v1.26.").Validate(), "Unsupported Kubernetes version")
+	assert.NoError(t, KubernetesVersion("v1.26.5").Validate())
+	assert.ErrorContains(t, KubernetesVersion("v1.1.1").Validate(), "Unsupported Kubernetes version")
 	assert.ErrorContains(t, KubernetesVersion("v1.26.100").Validate(), "Unsupported Kubernetes version")
 }
 

--- a/pkg/utils/validation/validators.go
+++ b/pkg/utils/validation/validators.go
@@ -59,6 +59,7 @@ func initialize() {
 	validate.RegisterValidation("extra_alphanumhyp", extra_AlphaNumericHyphen)
 	validate.RegisterValidation("extra_alphanumhypus", extra_AlphaNumericHyphenUnderscore)
 	validate.RegisterValidation("extra_vsemver", extra_VSemVer)
+	validate.RegisterValidation("extra_semverinrange", extra_SemVersionInRange)
 	validate.RegisterValidation("extra_ipinrange", extra_IPInRange)
 	validate.RegisterValidation("extra_uniquefield", extra_UniqueField)
 	validate.RegisterValidation("extra_regexany", extra_RegexAny)
@@ -427,6 +428,13 @@ func VSemVer() Validator {
 	return Validator{
 		Tags: "extra_vsemver",
 		Err:  "Field '{.Field}' must be a valid semantic version prefixed with 'v' (e.g. v1.2.3). (actual: {.Value})",
+	}
+}
+
+func SemVerInRange(min, max string) Validator {
+	return Validator{
+		Tags: fmt.Sprintf("extra_semverinrange=%s %s", min, max),
+		Err:  fmt.Sprintf("Field '{.Field}' must be in range [%s - %s] (actual: {.Value})", min, max),
 	}
 }
 

--- a/pkg/utils/validation/validators_extra.go
+++ b/pkg/utils/validation/validators_extra.go
@@ -54,6 +54,52 @@ func extra_VSemVer(fl validator.FieldLevel) bool {
 	return regex("^(v){1}(\\*|\\d+(\\.\\d+){2})$", fl.Field().String())
 }
 
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// parseVersion converts string into semantic version.
+func parseVersion(s string) Version {
+	var v Version
+	fmt.Sscanf(s, "%d.%d.%d", &v.Major, &v.Minor, &v.Patch)
+	return v
+}
+
+// isLessThan checks whether v1 is strictly less then v2.
+func isLessThan(v1, v2 Version) bool {
+	if v1.Major > v2.Major {
+		return false
+	}
+
+	if v1.Major < v2.Major {
+		return true
+	}
+
+	if v1.Minor > v2.Minor {
+		return false
+	}
+
+	if v1.Minor < v2.Minor {
+		return true
+	}
+
+	return v1.Patch < v2.Patch
+}
+
+// extra_SemVersionInRange checks whether version (field 1) is in range
+// of minimum (field 2) and maximum (field 3) version.
+func extra_SemVersionInRange(fl validator.FieldLevel) bool {
+	verRange := strings.Split(fl.Param(), " ")
+
+	ver := parseVersion(fl.Field().String())
+	min := parseVersion(verRange[0])
+	max := parseVersion(verRange[1])
+
+	return !isLessThan(ver, min) && !isLessThan(max, ver)
+}
+
 // extra_IPInRange checks whether the field is a valid IP within provided CIDR
 func extra_IPInRange(fl validator.FieldLevel) bool {
 	_, subnet, err := net.ParseCIDR(fl.Param())

--- a/pkg/utils/validation/validators_test.go
+++ b/pkg/utils/validation/validators_test.go
@@ -350,9 +350,79 @@ func TestVSemVer(t *testing.T) {
 	assert.Error(t, Var("1.2", VSemVer()))
 	assert.Error(t, Var("1", VSemVer()))
 	assert.Error(t, Var("", VSemVer()))
+	assert.Error(t, Var("1.2.", VSemVer()))
 	assert.Error(t, Var("1.2.*", VSemVer()))
 	assert.Error(t, Var("a.b.c", VSemVer()))
 	assert.Error(t, Var(nil, VSemVer()))
+}
+
+func TestSemVersionInRange(t *testing.T) {
+
+	tests := []struct {
+		expect bool
+		min    string
+		max    string
+		ver    string
+	}{
+		{expect: true, min: "2", max: "4", ver: "2"},
+		{expect: true, min: "2", max: "4", ver: "2.0"},
+		{expect: true, min: "2", max: "4", ver: "2.0.0"},
+		{expect: true, min: "2", max: "4", ver: "3"},
+		{expect: true, min: "2", max: "4", ver: "3.1"},
+		{expect: true, min: "2", max: "4", ver: "3.1.1"},
+		{expect: true, min: "2", max: "4", ver: "4"},
+		{expect: true, min: "2", max: "4", ver: "4.0"},
+		{expect: true, min: "2", max: "4", ver: "4.0.0"},
+
+		{expect: true, min: "2.0", max: "4.0", ver: "2"},
+		{expect: true, min: "2.0", max: "4.0", ver: "2.0"},
+		{expect: true, min: "2.0", max: "4.0", ver: "2.0.0"},
+		{expect: true, min: "2.0", max: "4.0", ver: "3"},
+		{expect: true, min: "2.0", max: "4.0", ver: "3.1"},
+		{expect: true, min: "2.0", max: "4.0", ver: "3.1.1"},
+		{expect: true, min: "2.0", max: "4.0", ver: "4"},
+		{expect: true, min: "2.0", max: "4.0", ver: "4.0"},
+		{expect: true, min: "2.0", max: "4.0", ver: "4.0.0"},
+
+		{expect: true, min: "2.0.0", max: "4.0.0", ver: "2"},
+		{expect: true, min: "2.0.0", max: "4.0.0", ver: "2.0"},
+		{expect: true, min: "2.0.0", max: "4.0.0", ver: "2.0.0"},
+		{expect: true, min: "2.0.0", max: "4.0.0", ver: "3"},
+		{expect: true, min: "2.0.0", max: "4.0.0", ver: "3.1"},
+		{expect: true, min: "2.0.0", max: "4.0.0", ver: "3.1.1"},
+		{expect: true, min: "2.0.0", max: "4.0.0", ver: "4"},
+		{expect: true, min: "2.0.0", max: "4.0.0", ver: "4.0"},
+		{expect: true, min: "2.0.0", max: "4.0.0", ver: "4.0.0"},
+
+		{expect: true, min: "2", max: "4.0.0", ver: "3"},
+		{expect: true, min: "2", max: "4.0.0", ver: "3.15"},
+		{expect: true, min: "2", max: "4.0.0", ver: "3.15.14"},
+		{expect: true, min: "2.0.0", max: "4", ver: "3"},
+		{expect: true, min: "2.0.0", max: "4", ver: "3.15"},
+		{expect: true, min: "2.0.0", max: "4", ver: "3.15.14"},
+
+		{expect: false, min: "2.2.2", max: "4.4.4", ver: "1"},
+		{expect: false, min: "2.2.2", max: "4.4.4", ver: "2.1"},
+		{expect: false, min: "2.2.2", max: "4.4.4", ver: "2.2.1"},
+		{expect: false, min: "2.2.2", max: "4.4.4", ver: "5"},
+		{expect: false, min: "2.2.2", max: "4.4.4", ver: "4.5"},
+		{expect: false, min: "2.2.2", max: "4.4.4", ver: "4.4.5"},
+
+		{expect: false, min: "0.0.1", max: "1.0.0", ver: ""},
+		{expect: false, min: "0.0.1", max: "1.0.0", ver: "test"},
+		{expect: false, min: "0.0.1", max: "1.0.0", ver: "a.b.c"},
+		{expect: false, min: "1.0.0", max: "0.0.0", ver: "0.0.5"},
+	}
+
+	for _, test := range tests {
+		result := Var(test.ver, SemVerInRange(test.min, test.max))
+
+		if test.expect {
+			assert.NoErrorf(t, result, "Version %q is not in range [%s - %s], but it should be!", test.ver, test.min, test.max)
+		} else {
+			assert.Errorf(t, result, "Version %q is in range [%s - %s], but it should not be!", test.ver, test.min, test.max)
+		}
+	}
 }
 
 func TestRegexAny(t *testing.T) {


### PR DESCRIPTION
Currently, `patch` part of the Kubernetes version is allowed to be any number between 0 and 99, which causes unsupported versions to be reported long after Kubitect's validation.

This PR improves Kubernetes version validation by matching only versions that are supported by Kubespray.

Fixes #156