### PR TITLE
reboot nodes after cloudinit

### DIFF
--- a/embed/terraform/templates/cloud_init/cloud_init.tpl
+++ b/embed/terraform/templates/cloud_init/cloud_init.tpl
@@ -24,3 +24,6 @@ bootcmd:
 runcmd:
   - [ systemctl, enable, qemu-guest-agent.service ]
   - [ systemctl, start, qemu-guest-agent.service ]
+
+power_state:
+  mode: reboot


### PR DESCRIPTION
while debugging #159 i noticed that after the package upgrades that kubitect applies when `updateOnBoot` is `true`, ubuntu reports that it needs a reboot to apply those upgrades. this change reboots the nodes using cloudinit after everything is done.

i'd also like to get your thoughts on whether or not this should be configurable / if `updateOnBoot` should be the one that sets reboot powerstate