### PR TITLE
Pin terraform-provider-libvirt to fix issue with ssh connections

### DIFF
--- a/embed/terraform/versions.tf
+++ b/embed/terraform/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "~> 0.7.1"
+      version = "0.7.1"
     }
   }
 }


### PR DESCRIPTION
* embed/terraform/versions.tf: Pin terraform-provider-libvirt to 0.7.1 as 0.7.4 results in a connection failure during provisioning

Fixes #163