### PR TITLE
Bump kubernetes version and update available images

### DIFF
--- a/docs/examples/full-example.md
+++ b/docs/examples/full-example.md
@@ -159,7 +159,7 @@ cluster:
 # such as version and network plugin.
 #
 kubernetes:
-  version: v1.24.7
+  version: v1.27.5
   networkPlugin: calico
   dnsMode: coredns # (36)!
   other:

--- a/docs/examples/ha-cluster.md
+++ b/docs/examples/ha-cluster.md
@@ -307,7 +307,7 @@ cluster:
                   size: 512
 
     kubernetes:
-      version: v1.24.7
+      version: v1.27.5
     ```
 
 ## Step 5: Applying the configuration

--- a/docs/examples/multi-master-cluster.md
+++ b/docs/examples/multi-master-cluster.md
@@ -123,7 +123,7 @@ The load balancer is then configured to distribute traffic received on port 6443
               ip: 192.168.113.22
 
     kubernetes:
-      version: v1.24.7
+      version: v1.27.5
       networkPlugin: calico
     ```
 

--- a/docs/examples/multi-worker-cluster.md
+++ b/docs/examples/multi-worker-cluster.md
@@ -85,7 +85,7 @@ cluster:
             - id: 99
 
     kubernetes:
-      version: v1.24.7
+      version: v1.27.5
       networkPlugin: calico
     ```
 

--- a/docs/examples/rook-cluster.md
+++ b/docs/examples/rook-cluster.md
@@ -131,7 +131,7 @@ However, this behavior can be restricted using node selectors, which are explain
                   size: 32
 
     kubernetes:
-      version: v1.24.7
+      version: v1.27.5
 
     addons:
       rook:
@@ -275,7 +275,7 @@ addons:
                   size: 32
 
     kubernetes:
-      version: v1.24.7
+      version: v1.27.5
 
     addons:
       rook:

--- a/docs/examples/single-node-cluster.md
+++ b/docs/examples/single-node-cluster.md
@@ -78,7 +78,7 @@ This means that the single master node in the cluster will perform both the cont
               ip: 192.168.113.10
 
     kubernetes:
-      version: v1.24.7
+      version: v1.27.5
       networkPlugin: calico
     ```
 

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -255,7 +255,7 @@ such as the version and network plugin.
 
 ```yaml title="kubitect.yaml"
 kubernetes:
-  version: v1.24.7
+  version: v1.27.5
   networkPlugin: calico
 ```
 
@@ -303,7 +303,7 @@ Below is the final configuration for our Kubernetes cluster:
               ram: 4
 
     kubernetes:
-      version: v1.24.7
+      version: v1.27.5
       networkPlugin: calico
     ```
 

--- a/docs/user-guide/configuration/cluster-node-template.md
+++ b/docs/user-guide/configuration/cluster-node-template.md
@@ -57,14 +57,14 @@ cluster:
 The available operating system distribution presets are:
 
 + **`ubuntu`** - Latest Ubuntu 22.04 release. (default)
-+ `ubuntu22` - Ubuntu 22.04 release as of *2023-06-06*.
-+ `ubuntu20` - Ubuntu 20.04 release as of *2023-06-06*.
++ `ubuntu22` - Ubuntu 22.04 release as of *2023-10-26*.
++ `ubuntu20` - Ubuntu 20.04 release as of *2023-10-11*.
 + **`debian`** - Latest Debian 11 release.
-+ `debian11` - Debian 11 release as of *2023-06-01*.
++ `debian11` - Debian 11 release as of *2023-10-13*.
 + **`rocky`** - Latest Rocky 9 release.
-+ `rocky9` - Rocky 9.1 release as of *2023-05-13*.
++ `rocky9` - Rocky 9.2 release as of *2023-05-13*.
 + **`centos`** - Latest CentOS Stream 9 release.
-+ `centos9` - CentOS Stream 9 release as of *2023-06-05*.
++ `centos9` - CentOS Stream 9 release as of *2023-10-23*.
 
 !!! warning "Important"
 

--- a/docs/user-guide/configuration/cluster-nodes.md
+++ b/docs/user-guide/configuration/cluster-nodes.md
@@ -533,9 +533,9 @@ The roles of the nodes in a Kubernetes cluster can be viewed using `kubectl get 
 
 ```
 NAME                   STATUS   ROLES                  AGE   VERSION
-k8s-cluster-master-1   Ready    control-plane,master   19m   v1.26.5
-k8s-cluster-worker-1   Ready    node                   19m   v1.26.5
-k8s-cluster-worker-2   Ready    node                   19m   v1.26.5
+k8s-cluster-master-1   Ready    control-plane,master   19m   v1.27.5
+k8s-cluster-worker-1   Ready    node                   19m   v1.27.5
+k8s-cluster-worker-2   Ready    node                   19m   v1.27.5
 ```
 
 ### Load balance HTTP requests

--- a/docs/user-guide/configuration/kubernetes.md
+++ b/docs/user-guide/configuration/kubernetes.md
@@ -16,17 +16,17 @@ The Kubernetes section of the configuration file contains properties that are sp
 
 :material-tag-arrow-up-outline: [v3.0.0][tag 3.0.0]
 &ensp;
-:octicons-file-symlink-file-24: Default: `v1.26.5`
+:octicons-file-symlink-file-24: Default: `v1.27.5`
 
-By default, the Kubernetes cluster will be deployed using version `v1.26.5`, but you can specify a different version if necessary.
+By default, the Kubernetes cluster will be deployed using version `v1.27.5`, but you can specify a different version if necessary.
 
 
 ```yaml
 kubernetes:
-  version: v1.24.7
+  version: v1.27.5
 ```
 
-The supported Kubernetes versions include `v1.24`, `v1.25`, and `v1.26`.
+The supported Kubernetes versions include `v1.25`, `v1.26`, and `v1.27`.
 
 ### Kubernetes network plugin
 

--- a/docs/user-guide/configuration/kubernetes.md
+++ b/docs/user-guide/configuration/kubernetes.md
@@ -52,9 +52,9 @@ The following table shows the compatibility matrix of supported network plugins 
 
 | Kubernetes Version |      Calico      |      Cilium      |      Flannel     |    KubeRouter    |       Weave      |
 |--------------------|:----------------:|:----------------:|:----------------:|:----------------:|:----------------:|
-| **1.24**           | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 | **1.25**           | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 | **1.26**           | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| **1.27**           | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 
 ### Kubernetes DNS mode
 

--- a/docs/user-guide/reference/configuration.md
+++ b/docs/user-guide/reference/configuration.md
@@ -781,7 +781,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
     <tr>
       <td><code>kubernetes.version</code></td>
       <td>string</td>
-      <td>v1.26.5</td>
+      <td>v1.27.5</td>
       <td></td>
       <td>Kubernetes version that will be installed.</td>
     </tr>

--- a/embed/presets/example-multi-master.yaml
+++ b/embed/presets/example-multi-master.yaml
@@ -38,5 +38,5 @@ cluster:
           ip: 192.168.113.22
 
 kubernetes:
-  version: v1.24.7
+  version: v1.27.5
   networkPlugin: calico

--- a/embed/presets/example-multi-worker.yaml
+++ b/embed/presets/example-multi-worker.yaml
@@ -29,5 +29,5 @@ cluster:
         - id: 99
 
 kubernetes:
-  version: v1.24.7
+  version: v1.27.5
   networkPlugin: calico

--- a/embed/presets/example-single-node.yaml
+++ b/embed/presets/example-single-node.yaml
@@ -26,5 +26,5 @@ cluster:
           ip: 192.168.113.10
 
 kubernetes:
-  version: v1.24.7
+  version: v1.27.5
   networkPlugin: calico

--- a/embed/presets/getting-started.yaml
+++ b/embed/presets/getting-started.yaml
@@ -25,7 +25,7 @@ cluster:
         - id: 1
           ip: 192.168.113.10
     worker:
-      default: 
+      default:
         ram: 8
         cpu: 2
         mainDiskSize: 32
@@ -35,5 +35,5 @@ cluster:
           ram: 4
 
 kubernetes:
-  version: v1.24.7
+  version: v1.27.5
   networkPlugin: calico

--- a/pkg/cluster/cluster_mock.go
+++ b/pkg/cluster/cluster_mock.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -8,12 +9,14 @@ import (
 	"github.com/MusicDin/kubitect/pkg/app"
 	"github.com/MusicDin/kubitect/pkg/cluster/executors"
 	"github.com/MusicDin/kubitect/pkg/cluster/provisioner"
+	"github.com/MusicDin/kubitect/pkg/env"
 	"github.com/MusicDin/kubitect/pkg/models/config"
 	"github.com/MusicDin/kubitect/pkg/ui"
 	"github.com/MusicDin/kubitect/pkg/utils/defaults"
 	"github.com/MusicDin/kubitect/pkg/utils/template"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type (
@@ -41,7 +44,7 @@ func MockCluster(t *testing.T) *ClusterMock {
 	ctx := app.MockAppContext(t, ctxOptions)
 
 	c, err := NewCluster(ctx, ConfigMock{}.Write(t))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create an empty SSH key pair
 	keyDir := t.TempDir()
@@ -78,7 +81,7 @@ func (c *ConfigMock) SetDefaults() {
 }
 
 func (c ConfigMock) Template() string {
-	return template.TrimTemplate(`
+	return template.TrimTemplate(fmt.Sprintf(`
 		hosts:
 			- name: localhost
 				connection:
@@ -94,10 +97,8 @@ func (c ConfigMock) Template() string {
 						- id: 1
 
 		kubernetes:
-			version: v1.24.7
-			kubespray:
-				version: v2.21.0
-	`)
+			version: %s
+	`, env.ConstKubernetesVersion))
 }
 
 func (c ConfigMock) Write(t *testing.T) string {

--- a/pkg/cluster/executors/kubespray/template_test.go
+++ b/pkg/cluster/executors/kubespray/template_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/MusicDin/kubitect/pkg/env"
 	"github.com/MusicDin/kubitect/pkg/models/config"
 	"github.com/MusicDin/kubitect/pkg/utils/template"
 	"gopkg.in/yaml.v3"
@@ -32,7 +33,7 @@ func TestKubesprayK8sClusterTemplate(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NoError(t, tpl.Write())
-	assert.Contains(t, pop, "kube_version: v1.24.7")
+	assert.Contains(t, pop, fmt.Sprintf("kube_version: %s", env.ConstKubernetesVersion))
 	assert.Contains(t, pop, "kube_network_plugin: calico")
 	assert.Contains(t, pop, "dns_mode: coredns")
 	assert.Contains(t, pop, "auto_renew_certificates: false")

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -9,8 +9,8 @@ const (
 	ConstProjectUrl        = "https://github.com/MusicDin/kubitect"
 	ConstProjectVersion    = "v3.2.2"
 	ConstKubesprayUrl      = "https://github.com/kubernetes-sigs/kubespray"
-	ConstKubesprayVersion  = "v2.22.1"
-	ConstKubernetesVersion = "v1.26.5"
+	ConstKubesprayVersion  = "v2.23.0"
+	ConstKubernetesVersion = "v1.27.5"
 	ConstTerraformVersion  = "1.5.2"
 )
 
@@ -37,9 +37,9 @@ var ProjectApplyActions = [...]string{
 
 // ProjectK8sVersions define supported Kubernetes versions.
 var ProjectK8sVersions = []string{
-	"v1.26.0 - v1.26.5",
-	"v1.25.0 - v1.25.10",
-	"v1.24.0 - v1.24.14",
+	"v1.27.0 - v1.27.5",
+	"v1.26.0 - v1.26.8",
+	"v1.25.0 - v1.25.13",
 }
 
 // ProjectOsPresets is a list of available OS distros.

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -52,11 +52,11 @@ var ProjectOsPresets = map[string]struct {
 		NetworkInterface: "ens3",
 	},
 	"ubuntu22": {
-		Source:           "https://cloud-images.ubuntu.com/releases/jammy/release-20230606/ubuntu-22.04-server-cloudimg-amd64.img",
+		Source:           "https://cloud-images.ubuntu.com/releases/jammy/release-20231026/ubuntu-22.04-server-cloudimg-amd64.img",
 		NetworkInterface: "ens3",
 	},
 	"ubuntu20": {
-		Source:           "https://cloud-images.ubuntu.com/releases/focal/release-20230606/ubuntu-20.04-server-cloudimg-amd64.img",
+		Source:           "https://cloud-images.ubuntu.com/releases/focal/release-20231011/ubuntu-20.04-server-cloudimg-amd64.img",
 		NetworkInterface: "ens3",
 	},
 	"debian": {
@@ -64,7 +64,7 @@ var ProjectOsPresets = map[string]struct {
 		NetworkInterface: "ens3",
 	},
 	"debian11": {
-		Source:           "https://cloud.debian.org/images/cloud/bullseye/20230601-1398/debian-11-genericcloud-amd64-20230601-1398.qcow2",
+		Source:           "https://cloud.debian.org/images/cloud/bullseye/20231013-1532/debian-11-genericcloud-amd64-20230601-1398.qcow2",
 		NetworkInterface: "ens3",
 	},
 	"centos": {
@@ -72,7 +72,7 @@ var ProjectOsPresets = map[string]struct {
 		NetworkInterface: "eth0",
 	},
 	"centos9": {
-		Source:           "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230605.0.x86_64.qcow2",
+		Source:           "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20231023.1.x86_64.qcow2",
 		NetworkInterface: "eth0",
 	},
 	"rocky": {

--- a/pkg/models/config/kubernetes_test.go
+++ b/pkg/models/config/kubernetes_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestKubernetesVersion(t *testing.T) {
-	assert.NoError(t, KubernetesVersion("v1.24.0").Validate())
-	assert.NoError(t, KubernetesVersion("v1.24.5").Validate())
 	assert.NoError(t, KubernetesVersion("v1.25.0").Validate())
 	assert.NoError(t, KubernetesVersion("v1.25.5").Validate())
 	assert.NoError(t, KubernetesVersion("v1.26.0").Validate())
 	assert.NoError(t, KubernetesVersion("v1.26.5").Validate())
+	assert.NoError(t, KubernetesVersion("v1.27.0").Validate())
+	assert.NoError(t, KubernetesVersion("v1.27.5").Validate())
 	assert.ErrorContains(t, KubernetesVersion("v1.1.1").Validate(), "Unsupported Kubernetes version")
-	assert.ErrorContains(t, KubernetesVersion("v1.26.100").Validate(), "Unsupported Kubernetes version")
+	assert.ErrorContains(t, KubernetesVersion("v1.28.100").Validate(), "Unsupported Kubernetes version")
 }
 
 func TestDnsMode(t *testing.T) {

--- a/pkg/models/config/mock.go
+++ b/pkg/models/config/mock.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/MusicDin/kubitect/pkg/env"
 	"github.com/MusicDin/kubitect/pkg/utils/defaults"
 
 	"github.com/stretchr/testify/assert"
@@ -119,7 +120,7 @@ func MockConfig(t *testing.T) Config {
 			},
 		},
 		Kubernetes: Kubernetes{
-			Version: "v1.24.7",
+			Version: env.ConstKubernetesVersion,
 		},
 	}
 


### PR DESCRIPTION
- Kubespray `v2.22.1` -> `v2.23.0`

- Images:
  + Ubuntu22 `2023.06.06` -> `2023.10.26`
  + Ubuntu20 `2023.06.06` -> `2023.10.11`
  + Debian11 `2023.06.01` -> `2023.10.13`
  + Centos9  `2023.06.05` -> `2023.10.23`

- Kubernetes:
  + Default version: `v1.26.5` -> `v1.27.5`
  + Spported versions: ~`1.24`~, `v1.25`, `v1.26`, `v1.27`