### PR TITLE
Remove Weave network plugin

### DIFF
--- a/docs/user-guide/configuration/kubernetes.md
+++ b/docs/user-guide/configuration/kubernetes.md
@@ -41,7 +41,6 @@ However, there are multiple supported network plugins available to choose from:
 - `cilium`
 - `flannel`
 - `kube-router`
-- `weave`
 
 ```yaml
 kubernetes:
@@ -50,11 +49,11 @@ kubernetes:
 
 The following table shows the compatibility matrix of supported network plugins and Kubernetes versions:
 
-| Kubernetes Version |      Calico      |      Cilium      |      Flannel     |    KubeRouter    |       Weave      |
-|--------------------|:----------------:|:----------------:|:----------------:|:----------------:|:----------------:|
-| **1.25**           | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| **1.26**           | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
-| **1.27**           | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| Kubernetes Version |      Calico      |      Cilium      |      Flannel     |    KubeRouter    |
+|--------------------|:----------------:|:----------------:|:----------------:|:----------------:|
+| **1.25**           | :material-check: | :material-check: | :material-check: | :material-check: |
+| **1.26**           | :material-check: | :material-check: | :material-check: | :material-check: |
+| **1.27**           | :material-check: | :material-check: | :material-check: | :material-check: |
 
 ### Kubernetes DNS mode
 

--- a/docs/user-guide/reference/configuration.md
+++ b/docs/user-guide/reference/configuration.md
@@ -755,7 +755,6 @@ Each configuration property is documented with 5 columns: Property name, descrip
           <li><code>cilium</code></li>
           <li><code>flannel</code></li>
           <li><code>kube-router</code></li>
-          <li><code>weave</code></li>
         </ul>
       </td>
     </tr>

--- a/pkg/models/config/kubernetes.go
+++ b/pkg/models/config/kubernetes.go
@@ -75,12 +75,11 @@ const (
 	CALICO      NetworkPlugin = "calico"
 	CILIUM      NetworkPlugin = "cilium"
 	FLANNEL     NetworkPlugin = "flannel"
-	WEAVE       NetworkPlugin = "weave"
 	KUBE_ROUTER NetworkPlugin = "kube-router"
 )
 
 func (p NetworkPlugin) Validate() error {
-	return v.Var(p, v.OneOf(CALICO, CILIUM, FLANNEL, WEAVE, KUBE_ROUTER))
+	return v.Var(p, v.OneOf(CALICO, CILIUM, FLANNEL, KUBE_ROUTER))
 }
 
 type Other struct {


### PR DESCRIPTION
Weave network plugin is deprecated and should be removed.