### PR TITLE
Use only latest images

### DIFF
--- a/docs/examples/full-example.md
+++ b/docs/examples/full-example.md
@@ -69,7 +69,7 @@ cluster:
       privateKeyPath: "~/.ssh/id_rsa_test"
       addToKnownHosts: true
     os:
-      distro: ubuntu
+      distro: ubuntu22
       networkInterface: ens3 # (20)!
     dns: # (21)!
       - 1.1.1.1

--- a/docs/examples/ha-cluster.md
+++ b/docs/examples/ha-cluster.md
@@ -260,7 +260,7 @@ cluster:
         ssh:
           addToKnownHosts: true
         os:
-          distro: ubuntu
+          distro: ubuntu22
       nodes:
         loadBalancer:
           vip: 10.10.13.200

--- a/docs/examples/multi-master-cluster.md
+++ b/docs/examples/multi-master-cluster.md
@@ -99,7 +99,7 @@ The load balancer is then configured to distribute traffic received on port 6443
         ssh:
           addToKnownHosts: true
         os:
-          distro: ubuntu
+          distro: ubuntu22
       nodes:
         loadBalancer:
           instances:

--- a/docs/examples/multi-worker-cluster.md
+++ b/docs/examples/multi-worker-cluster.md
@@ -70,7 +70,7 @@ cluster:
         ssh:
           addToKnownHosts: true
         os:
-          distro: ubuntu
+          distro: ubuntu22
       nodes:
         master:
           instances:

--- a/docs/examples/rook-cluster.md
+++ b/docs/examples/rook-cluster.md
@@ -103,7 +103,7 @@ However, this behavior can be restricted using node selectors, which are explain
         ssh:
           addToKnownHosts: true
         os:
-          distro: ubuntu
+          distro: ubuntu22
       nodes:
         master:
           instances:
@@ -238,7 +238,7 @@ addons:
         ssh:
           addToKnownHosts: true
         os:
-          distro: ubuntu
+          distro: ubuntu22
       nodes:
         master:
           instances:

--- a/docs/examples/single-node-cluster.md
+++ b/docs/examples/single-node-cluster.md
@@ -66,7 +66,7 @@ This means that the single master node in the cluster will perform both the cont
         ssh:
           addToKnownHosts: true
         os:
-          distro: ubuntu
+          distro: ubuntu22
       nodes:
         master:
           default:

--- a/docs/user-guide/configuration/cluster-node-template.md
+++ b/docs/user-guide/configuration/cluster-node-template.md
@@ -37,7 +37,7 @@ cluster:
 
 :material-tag-arrow-up-outline: [v2.1.0][tag 2.1.0]
 &ensp;
-:octicons-file-symlink-file-24: Default: `ubuntu`
+:octicons-file-symlink-file-24: Default: `ubuntu22`
 
 The operating system for virtual machines can be specified in the node template.
 By default, the Ubuntu distribution is installed on all virtual machines.
@@ -48,23 +48,20 @@ You can select a desired distribution by setting the `os.distro` property.
 cluster:
   nodeTemplate:
     os:
-      distro: debian # (1)!
+      distro: debian12 # (1)!
 ```
 
-1. By default, `ubuntu` is used.
+1. By default, `ubuntu22` is used.
 
 
 The available operating system distribution presets are:
 
-+ **`ubuntu`** - Latest Ubuntu 22.04 release. (default)
-+ `ubuntu22` - Ubuntu 22.04 release as of *2023-10-26*.
-+ `ubuntu20` - Ubuntu 20.04 release as of *2023-10-11*.
-+ **`debian`** - Latest Debian 11 release.
-+ `debian11` - Debian 11 release as of *2023-10-13*.
-+ **`rocky`** - Latest Rocky 9 release.
-+ `rocky9` - Rocky 9.2 release as of *2023-05-13*.
-+ **`centos`** - Latest CentOS Stream 9 release.
-+ `centos9` - CentOS Stream 9 release as of *2023-10-23*.
++ **`ubuntu20`** - Latest Ubuntu 20.04 (Focal) release.
++ **`ubuntu22`** - Latest Ubuntu 22.04 (Jammy) release. (default)
++ **`debian11`** - Latest Debian 11 (Bullseye) release.
++ **`debian12`** - Latest Debian 12 (Bookworm) release.
++ **`centos9`** - Latest CentOS Stream 9 release.
++ **`rocky9`** - Latest Rocky 9 release.
 
 !!! warning "Important"
 
@@ -98,7 +95,7 @@ The source of an image can be either a local path on your system or a URL pointi
 cluster:
   nodeTemplate:
     os:
-      distro: ubuntu
+      distro: ubuntu20
       source: https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
 ```
 

--- a/docs/user-guide/reference/configuration.md
+++ b/docs/user-guide/reference/configuration.md
@@ -642,20 +642,17 @@ Each configuration property is documented with 5 columns: Property name, descrip
     <tr>
       <td><code>cluster.nodeTemplate.os.distro</code></td>
       <td>string</td>
-      <td>ubuntu</td>
+      <td>ubuntu22</td>
       <td></td>
       <td>
         Set OS distribution. Possible values are:
         <ul>
-          <li><code>ubuntu</code></li>
-          <li><code>ubuntu22</code></li>
           <li><code>ubuntu20</code></li>
-          <li><code>debian</code></li>
+          <li><code>ubuntu22</code></li>
           <li><code>debian11</code></li>
-          <li><code>rocky</code></li>
-          <li><code>rocky9</code></li>
-          <li><code>centos</code></li>
+          <li><code>debian12</code></li>
           <li><code>centos9</code></li>
+          <li><code>rocky9</code></li>
         </ul>
       </td>
     </tr>

--- a/embed/presets/example-multi-master.yaml
+++ b/embed/presets/example-multi-master.yaml
@@ -14,7 +14,7 @@ cluster:
     ssh:
       addToKnownHosts: true
     os:
-      distro: ubuntu
+      distro: ubuntu22
   nodes:
     loadBalancer:
       instances:

--- a/embed/presets/example-multi-worker.yaml
+++ b/embed/presets/example-multi-worker.yaml
@@ -14,7 +14,7 @@ cluster:
     ssh:
       addToKnownHosts: true
     os:
-      distro: ubuntu
+      distro: ubuntu22
   nodes:
     master:
       instances:

--- a/embed/presets/example-single-node.yaml
+++ b/embed/presets/example-single-node.yaml
@@ -14,7 +14,7 @@ cluster:
     ssh:
       addToKnownHosts: true
     os:
-      distro: ubuntu
+      distro: ubuntu22
   nodes:
     master:
       default:

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -47,40 +47,28 @@ var ProjectOsPresets = map[string]struct {
 	Source           string
 	NetworkInterface string
 }{
-	"ubuntu": {
-		Source:           "https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img",
+	"ubuntu20": {
+		Source:           "https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img",
 		NetworkInterface: "ens3",
 	},
 	"ubuntu22": {
-		Source:           "https://cloud-images.ubuntu.com/releases/jammy/release-20231026/ubuntu-22.04-server-cloudimg-amd64.img",
-		NetworkInterface: "ens3",
-	},
-	"ubuntu20": {
-		Source:           "https://cloud-images.ubuntu.com/releases/focal/release-20231011/ubuntu-20.04-server-cloudimg-amd64.img",
-		NetworkInterface: "ens3",
-	},
-	"debian": {
-		Source:           "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-amd64.qcow2",
+		Source:           "https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img",
 		NetworkInterface: "ens3",
 	},
 	"debian11": {
-		Source:           "https://cloud.debian.org/images/cloud/bullseye/20231013-1532/debian-11-genericcloud-amd64-20230601-1398.qcow2",
+		Source:           "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-amd64.qcow2",
 		NetworkInterface: "ens3",
 	},
-	"centos": {
+	"debian12": {
+		Source:           "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2",
+		NetworkInterface: "ens3",
+	},
+	"centos9": {
 		Source:           "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2",
 		NetworkInterface: "eth0",
 	},
-	"centos9": {
-		Source:           "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20231023.1.x86_64.qcow2",
-		NetworkInterface: "eth0",
-	},
-	"rocky": {
-		Source:           "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2",
-		NetworkInterface: "eth0",
-	},
 	"rocky9": {
-		Source:           "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.2-20230513.0.x86_64.qcow2",
+		Source:           "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2",
 		NetworkInterface: "eth0",
 	},
 }

--- a/pkg/models/config/cluster_node_template.go
+++ b/pkg/models/config/cluster_node_template.go
@@ -48,7 +48,7 @@ func (s OS) Validate() error {
 }
 
 func (s *OS) SetDefaults() {
-	s.Distro = defaults.Default(s.Distro, UBUNTU)
+	s.Distro = defaults.Default(s.Distro, UBUNTU22)
 
 	preset := env.ProjectOsPresets[string(s.Distro)]
 	s.NetworkInterface = defaults.Default(s.NetworkInterface, OSNetworkInterface(preset.NetworkInterface))
@@ -58,19 +58,16 @@ func (s *OS) SetDefaults() {
 type OSDistro string
 
 const (
-	UBUNTU   OSDistro = "ubuntu"
-	UBUNTU20 OSDistro = "ubuntu20"
 	UBUNTU22 OSDistro = "ubuntu22"
-	DEBIAN   OSDistro = "debian"
+	UBUNTU20 OSDistro = "ubuntu20"
 	DEBIAN11 OSDistro = "debian11"
-	CENTOS   OSDistro = "centos"
+	DEBIAN12 OSDistro = "debian12"
 	CENTOS9  OSDistro = "centos9"
-	ROCKY    OSDistro = "rocky"
 	ROCKY9   OSDistro = "rocky9"
 )
 
 func (d OSDistro) Validate() error {
-	return v.Var(d, v.OneOf(UBUNTU, UBUNTU20, UBUNTU22, DEBIAN, DEBIAN11, CENTOS, CENTOS9, ROCKY, ROCKY9))
+	return v.Var(d, v.OneOf(UBUNTU20, UBUNTU22, DEBIAN11, DEBIAN12, CENTOS9, ROCKY9))
 }
 
 type OSNetworkInterface string

--- a/pkg/models/config/cluster_node_template_test.go
+++ b/pkg/models/config/cluster_node_template_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestOSDistro(t *testing.T) {
-	assert.NoError(t, OSDistro(UBUNTU).Validate())
-	assert.NoError(t, OSDistro("ubuntu").Validate())
-	assert.NoError(t, OSDistro("debian").Validate())
-	assert.Error(t, OSDistro("wrong").Validate())
+	assert.NoError(t, OSDistro(UBUNTU20).Validate())
+	assert.NoError(t, OSDistro("ubuntu22").Validate())
+	assert.NoError(t, OSDistro("debian12").Validate())
+	assert.Error(t, OSDistro("invalid").Validate())
 }
 
 func TestOSDistro_Presets(t *testing.T) {
@@ -30,13 +30,13 @@ func TestOSNetworkInterface(t *testing.T) {
 }
 
 func TestOS_Empty(t *testing.T) {
-	assert.ErrorContains(t, OS{}.Validate(), "Field 'distro' must be one of the following values: [ubuntu|")
+	assert.ErrorContains(t, OS{}.Validate(), "Field 'distro' must be one of the following values: [ubuntu20|")
 	assert.ErrorContains(t, OS{}.Validate(), "Field 'networkInterface' can contain only alphanumeric characters.")
 }
 
 func TestOS_Defaults(t *testing.T) {
-	os1 := OS{Distro: UBUNTU}
-	os2 := OS{Distro: ROCKY}
+	os1 := OS{Distro: CENTOS9}
+	os2 := OS{Distro: ROCKY9}
 	os3 := OS{Source: OSSource("./cluster_node_template_test.go")}
 
 	assert.NoError(t, defaults.Assign(&OS{}).Validate())
@@ -44,14 +44,14 @@ func TestOS_Defaults(t *testing.T) {
 	assert.NoError(t, defaults.Assign(&os2).Validate())
 	assert.NoError(t, defaults.Assign(&os3).Validate())
 
-	assert.Equal(t, UBUNTU, os1.Distro)
-	assert.Equal(t, ROCKY, os2.Distro)
-	assert.Equal(t, UBUNTU, os3.Distro)
-	assert.Equal(t, "ens3", string(os1.NetworkInterface))
+	assert.Equal(t, CENTOS9, os1.Distro)
+	assert.Equal(t, ROCKY9, os2.Distro)
+	assert.Equal(t, UBUNTU22, os3.Distro)
+	assert.Equal(t, "eth0", string(os1.NetworkInterface))
 	assert.Equal(t, "eth0", string(os2.NetworkInterface))
 	assert.Equal(t, "ens3", string(os3.NetworkInterface))
-	assert.Equal(t, env.ProjectOsPresets["ubuntu"].Source, string(os1.Source))
-	assert.Equal(t, env.ProjectOsPresets["rocky"].Source, string(os2.Source))
+	assert.Equal(t, env.ProjectOsPresets["centos9"].Source, string(os1.Source))
+	assert.Equal(t, env.ProjectOsPresets["rocky9"].Source, string(os2.Source))
 	assert.Equal(t, "./cluster_node_template_test.go", string(os3.Source))
 }
 


### PR DESCRIPTION
Instead of pinning certain images to a specific version, always use latest images.

This PR removes the following image options:
- `ubuntu` -> Use `ubuntu22` instead.
- `debian` -> Use `ubuntu12` instead.
- `centos` -> Use `centos9` instead.
- `rocky` -> Use `rocky9` instead.