### PR TITLE
Bump Kubespray to 1.24.1

### DIFF
--- a/docs/examples/full-example.md
+++ b/docs/examples/full-example.md
@@ -159,7 +159,7 @@ cluster:
 # such as version and network plugin.
 #
 kubernetes:
-  version: v1.27.5
+  version: v1.28.6
   networkPlugin: calico
   dnsMode: coredns # (36)!
   other:

--- a/docs/examples/ha-cluster.md
+++ b/docs/examples/ha-cluster.md
@@ -307,7 +307,7 @@ cluster:
                   size: 512
 
     kubernetes:
-      version: v1.27.5
+      version: v1.28.6
     ```
 
 ## Step 5: Applying the configuration

--- a/docs/examples/multi-master-cluster.md
+++ b/docs/examples/multi-master-cluster.md
@@ -123,7 +123,7 @@ The load balancer is then configured to distribute traffic received on port 6443
               ip: 192.168.113.22
 
     kubernetes:
-      version: v1.27.5
+      version: v1.28.6
       networkPlugin: calico
     ```
 

--- a/docs/examples/multi-worker-cluster.md
+++ b/docs/examples/multi-worker-cluster.md
@@ -85,7 +85,7 @@ cluster:
             - id: 99
 
     kubernetes:
-      version: v1.27.5
+      version: v1.28.6
       networkPlugin: calico
     ```
 

--- a/docs/examples/rook-cluster.md
+++ b/docs/examples/rook-cluster.md
@@ -131,7 +131,7 @@ However, this behavior can be restricted using node selectors, which are explain
                   size: 32
 
     kubernetes:
-      version: v1.27.5
+      version: v1.28.6
 
     addons:
       rook:
@@ -275,7 +275,7 @@ addons:
                   size: 32
 
     kubernetes:
-      version: v1.27.5
+      version: v1.28.6
 
     addons:
       rook:

--- a/docs/examples/single-node-cluster.md
+++ b/docs/examples/single-node-cluster.md
@@ -78,7 +78,7 @@ This means that the single master node in the cluster will perform both the cont
               ip: 192.168.113.10
 
     kubernetes:
-      version: v1.27.5
+      version: v1.28.6
       networkPlugin: calico
     ```
 

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -255,7 +255,7 @@ such as the version and network plugin.
 
 ```yaml title="kubitect.yaml"
 kubernetes:
-  version: v1.27.5
+  version: v1.28.6
   networkPlugin: calico
 ```
 
@@ -303,7 +303,7 @@ Below is the final configuration for our Kubernetes cluster:
               ram: 4
 
     kubernetes:
-      version: v1.27.5
+      version: v1.28.6
       networkPlugin: calico
     ```
 

--- a/docs/user-guide/configuration/cluster-nodes.md
+++ b/docs/user-guide/configuration/cluster-nodes.md
@@ -533,9 +533,9 @@ The roles of the nodes in a Kubernetes cluster can be viewed using `kubectl get 
 
 ```
 NAME                   STATUS   ROLES                  AGE   VERSION
-k8s-cluster-master-1   Ready    control-plane,master   19m   v1.27.5
-k8s-cluster-worker-1   Ready    node                   19m   v1.27.5
-k8s-cluster-worker-2   Ready    node                   19m   v1.27.5
+k8s-cluster-master-1   Ready    control-plane,master   19m   v1.28.6
+k8s-cluster-worker-1   Ready    node                   19m   v1.28.6
+k8s-cluster-worker-2   Ready    node                   19m   v1.28.6
 ```
 
 ### Load balance HTTP requests

--- a/docs/user-guide/configuration/kubernetes.md
+++ b/docs/user-guide/configuration/kubernetes.md
@@ -16,17 +16,17 @@ The Kubernetes section of the configuration file contains properties that are sp
 
 :material-tag-arrow-up-outline: [v3.0.0][tag 3.0.0]
 &ensp;
-:octicons-file-symlink-file-24: Default: `v1.27.5`
+:octicons-file-symlink-file-24: Default: `v1.28.6`
 
-By default, the Kubernetes cluster will be deployed using version `v1.27.5`, but you can specify a different version if necessary.
+By default, the Kubernetes cluster will be deployed using version `v1.28.6`, but you can specify a different version if necessary.
 
 
 ```yaml
 kubernetes:
-  version: v1.27.5
+  version: v1.28.6
 ```
 
-The supported Kubernetes versions include `v1.25`, `v1.26`, and `v1.27`.
+The supported Kubernetes versions include `v1.26`, `v1.27`, and `v1.28`.
 
 ### Kubernetes network plugin
 
@@ -51,9 +51,9 @@ The following table shows the compatibility matrix of supported network plugins 
 
 | Kubernetes Version |      Calico      |      Cilium      |      Flannel     |    KubeRouter    |
 |--------------------|:----------------:|:----------------:|:----------------:|:----------------:|
-| **1.25**           | :material-check: | :material-check: | :material-check: | :material-check: |
 | **1.26**           | :material-check: | :material-check: | :material-check: | :material-check: |
 | **1.27**           | :material-check: | :material-check: | :material-check: | :material-check: |
+| **1.28**           | :material-check: | :material-check: | :material-check: | :material-check: |
 
 ### Kubernetes DNS mode
 

--- a/docs/user-guide/reference/configuration.md
+++ b/docs/user-guide/reference/configuration.md
@@ -780,7 +780,7 @@ Each configuration property is documented with 5 columns: Property name, descrip
     <tr>
       <td><code>kubernetes.version</code></td>
       <td>string</td>
-      <td>v1.27.5</td>
+      <td>v1.28.6</td>
       <td></td>
       <td>Kubernetes version that will be installed.</td>
     </tr>

--- a/embed/presets/example-multi-master.yaml
+++ b/embed/presets/example-multi-master.yaml
@@ -38,5 +38,5 @@ cluster:
           ip: 192.168.113.22
 
 kubernetes:
-  version: v1.27.5
+  version: v1.28.6
   networkPlugin: calico

--- a/embed/presets/example-multi-worker.yaml
+++ b/embed/presets/example-multi-worker.yaml
@@ -29,5 +29,5 @@ cluster:
         - id: 99
 
 kubernetes:
-  version: v1.27.5
+  version: v1.28.6
   networkPlugin: calico

--- a/embed/presets/example-single-node.yaml
+++ b/embed/presets/example-single-node.yaml
@@ -26,5 +26,5 @@ cluster:
           ip: 192.168.113.10
 
 kubernetes:
-  version: v1.27.5
+  version: v1.28.6
   networkPlugin: calico

--- a/embed/presets/getting-started.yaml
+++ b/embed/presets/getting-started.yaml
@@ -35,5 +35,5 @@ cluster:
           ram: 4
 
 kubernetes:
-  version: v1.27.5
+  version: v1.28.6
   networkPlugin: calico

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -9,8 +9,8 @@ const (
 	ConstProjectUrl        = "https://github.com/MusicDin/kubitect"
 	ConstProjectVersion    = "v3.3.1"
 	ConstKubesprayUrl      = "https://github.com/kubernetes-sigs/kubespray"
-	ConstKubesprayVersion  = "v2.23.1"
-	ConstKubernetesVersion = "v1.27.5"
+	ConstKubesprayVersion  = "v2.24.1"
+	ConstKubernetesVersion = "v1.28.6"
 	ConstTerraformVersion  = "1.5.2"
 )
 
@@ -37,9 +37,9 @@ var ProjectApplyActions = [...]string{
 
 // ProjectK8sVersions define supported Kubernetes versions.
 var ProjectK8sVersions = []string{
-	"v1.27.0 - v1.27.7",
-	"v1.26.0 - v1.26.10",
-	"v1.25.0 - v1.25.15",
+	"v1.28.0 - v1.28.6",
+	"v1.27.0 - v1.27.10",
+	"v1.26.0 - v1.26.13",
 }
 
 // ProjectOsPresets is a list of available OS distros.

--- a/pkg/models/config/kubernetes_test.go
+++ b/pkg/models/config/kubernetes_test.go
@@ -10,12 +10,10 @@ import (
 )
 
 func TestKubernetesVersion(t *testing.T) {
-	assert.NoError(t, KubernetesVersion("v1.25.0").Validate())
-	assert.NoError(t, KubernetesVersion("v1.25.5").Validate())
-	assert.NoError(t, KubernetesVersion("v1.26.0").Validate())
-	assert.NoError(t, KubernetesVersion("v1.26.5").Validate())
 	assert.NoError(t, KubernetesVersion("v1.27.0").Validate())
 	assert.NoError(t, KubernetesVersion("v1.27.5").Validate())
+	assert.NoError(t, KubernetesVersion("v1.28.0").Validate())
+	assert.NoError(t, KubernetesVersion("v1.28.5").Validate())
 	assert.ErrorContains(t, KubernetesVersion("v1.1.1").Validate(), "Unsupported Kubernetes version")
 	assert.ErrorContains(t, KubernetesVersion("v1.28.100").Validate(), "Unsupported Kubernetes version")
 }


### PR DESCRIPTION
This PR bumps Kubespray to `1.24.1`.

In addition it drops support for Kubernetes `1.25` and adds option for Kubernetes `1.28` (specifically: `v1.28.0` - `v1.28.6`).