### PR TITLE
Fail validation if config contains unknown keys

### DIFF
--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -58,7 +58,7 @@ func TestNewCluster_EmptyConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = NewCluster(app.MockAppContext(t), cfgPath)
-	assert.ErrorContains(t, err, "invalid configuration file")
+	assert.ErrorContains(t, err, "is empty")
 }
 
 func TestSync_FailReadingAppliedConfig(t *testing.T) {

--- a/pkg/cluster/utils.go
+++ b/pkg/cluster/utils.go
@@ -2,19 +2,29 @@ package cluster
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/MusicDin/kubitect/pkg/utils/file"
 	v "github.com/MusicDin/kubitect/pkg/utils/validation"
 )
 
 // readConfig reads configuration file on the given path and converts it into
-// the provided model.
+// the provided model. Function fails if config contains any unknown key.
 func readConfig[T v.Validatable](path string, model T) (*T, error) {
 	if !file.Exists(path) {
 		return nil, fmt.Errorf("file '%s' does not exist", path)
 	}
 
-	return file.ReadYaml(path, model)
+	cfg, err := file.ReadYamlStrict(path, model)
+	if err != nil {
+		if err == io.EOF {
+			return nil, fmt.Errorf("config file %q is empty", path)
+		}
+
+		return nil, fmt.Errorf("invalid config file %q\n%v", path, err)
+	}
+
+	return cfg, nil
 }
 
 // readConfig reads configuration file on the given path and converts it into

--- a/pkg/utils/file/file.go
+++ b/pkg/utils/file/file.go
@@ -73,7 +73,7 @@ func ForceCopy(srcPath, dstPath string, mode fs.FileMode) error {
 
 // ReadYaml reads yaml file on the given path and unmarshals it into the given
 // type.
-func ReadYaml[T interface{}](path string, typ T) (*T, error) {
+func ReadYaml[T any](path string, typ T) (*T, error) {
 	yml, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -83,8 +83,26 @@ func ReadYaml[T interface{}](path string, typ T) (*T, error) {
 	return &typ, err
 }
 
+// ReadYaml reads yaml file on the given path and unmarshals it into the given
+// type. File is not allowed to contain any unused/extra keys.
+func ReadYamlStrict[T any](path string, typ T) (*T, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := yaml.NewDecoder(file)
+	decoder.KnownFields(true)
+	err = decoder.Decode(&typ)
+	if err != nil {
+		return nil, err
+	}
+
+	return &typ, nil
+}
+
 // WriteYaml writes a given object as a yaml file to the given path.
-func WriteYaml(obj interface{}, path string, perm fs.FileMode) error {
+func WriteYaml(obj any, path string, perm fs.FileMode) error {
 	yml, err := yaml.Marshal(obj)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fail validation if config contains unknown keys to make it easier to detect typos.