### PR TITLE
k3s: Fix server startup in HA mode

### DIFF
--- a/pkg/cluster/managers/k3s.go
+++ b/pkg/cluster/managers/k3s.go
@@ -69,9 +69,7 @@ func (e *k3s) Init() error {
 	}
 
 	// Clone repository with k3s playbooks.
-	url := env.ConstK3sURL
-	commitHash := env.ConstK3sVersion
-	err = git.NewGitRepo(url).WithCommitHash(commitHash).Clone(e.ProjectDir)
+	err = git.NewGitRepo(env.ConstK3sURL).WithRef(env.ConstK3sVersion).Clone(e.ProjectDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -8,8 +8,8 @@ package env
 const (
 	ConstProjectUrl        = "https://github.com/MusicDin/kubitect"
 	ConstProjectVersion    = "v3.3.1"
-	ConstK3sURL            = "https://github.com/k3s-io/k3s-ansible"
-	ConstK3sVersion        = "7ec16a8d53363ace979e5585323311ab1bd1641d" // K3s has no tags, therefore use specific commit hash.
+	ConstK3sURL            = "https://github.com/MusicDin/k3s-ansible"
+	ConstK3sVersion        = "v0.0.1"
 	ConstKubesprayUrl      = "https://github.com/kubernetes-sigs/kubespray"
 	ConstKubesprayVersion  = "v2.24.1"
 	ConstKubernetesVersion = "v1.28.6"


### PR DESCRIPTION
K3s server occasionally starts before main node is ready causing playbook to exit. Use fork which is synced with official k3s-ansible repository and tagged for easier reference.