### PR TITLE
Add support for k8s 1.30

### DIFF
--- a/.github/workflows/tests-deployment.yml
+++ b/.github/workflows/tests-deployment.yml
@@ -28,8 +28,8 @@ jobs:
           - kubespray
           - k3s
         k8s:
-          - v1.28.10
-          - v1.29.5
+          - v1.29.7
+          - v1.30.4
         distro:
           - ubuntu22
         networkPlugin:
@@ -66,8 +66,8 @@ jobs:
           - k3s
           - kubespray
         k8sVersion:
-          - v1.28.10
-          - v1.29.5
+          - v1.29.7
+          - v1.30.4
         distro:
           - ubuntu22
         networkPlugin:
@@ -109,9 +109,9 @@ jobs:
           - k3s
           - kubespray
         k8sVersion:
-          - v1.27.14
-          - v1.28.10
-          - v1.29.5
+          - v1.28.12
+          - v1.29.7
+          - v1.30.4
         distro:
           - ubuntu22
           - debian12

--- a/docs/user-guide/configuration/kubernetes.md
+++ b/docs/user-guide/configuration/kubernetes.md
@@ -44,7 +44,7 @@ kubernetes:
   version: v1.28.6
 ```
 
-The supported Kubernetes versions include `v1.27`, `v1.28`, and `v1.29`.
+The supported Kubernetes versions include `v1.28`, `v1.29`, and `v1.30`.
 
 ### Kubernetes network plugin
 
@@ -69,10 +69,6 @@ The following table shows the compatibility matrix of supported network plugins 
 
 | Kubernetes Version | Operating system |      Calico      |      Cilium      |      Flannel     |    KubeRouter    |
 |--------------------|:-----------------|:----------------:|:----------------:|:----------------:|:----------------:|
-| **1.27**           | Ubuntu           | :material-check: | :material-check: | :material-check: | :material-check: |
-| **1.27**           | Debian           | :material-check: | :material-check: | :material-check: | :material-check: |
-| **1.27**           | CentOS           | :material-check: | :material-check: | :material-check: | :material-check: |
-| **1.27**           | RockyLinux       | :material-check: | :material-check: | :material-check: | :material-check: |
 | **1.28**           | Ubuntu           | :material-check: | :material-check: | :material-check: | :material-check: |
 | **1.28**           | Debian           | :material-check: | :material-check: | :material-check: | :material-check: |
 | **1.28**           | CentOS           | :material-check: | :material-check: | :material-check: | :material-check: |
@@ -81,7 +77,10 @@ The following table shows the compatibility matrix of supported network plugins 
 | **1.29**           | Debian           | :material-check: | :material-check: | :material-check: | :material-check: |
 | **1.29**           | CentOS           | :material-check: | :material-check: | :material-check: | :material-check: |
 | **1.29**           | RockyLinux       | :material-check: | :material-check: | :material-check: | :material-check: |
-
+| **1.30**           | Ubuntu           | :material-check: | :material-check: | :material-check: | :material-check: |
+| **1.30**           | Debian           | :material-check: | :material-check: | :material-check: | :material-check: |
+| **1.30**           | CentOS           | :material-check: | :material-check: | :material-check: | :material-check: |
+| **1.30**           | RockyLinux       | :material-check: | :material-check: | :material-check: | :material-check: |
 
 !!! note "Note"
 

--- a/pkg/env/constants.go
+++ b/pkg/env/constants.go
@@ -11,8 +11,8 @@ const (
 	ConstK3sURL            = "https://github.com/MusicDin/k3s-ansible"
 	ConstK3sVersion        = "v0.0.1"
 	ConstKubesprayUrl      = "https://github.com/kubernetes-sigs/kubespray"
-	ConstKubesprayVersion  = "v2.25.0"
-	ConstKubernetesVersion = "v1.28.6"
+	ConstKubesprayVersion  = "v2.26.0"
+	ConstKubernetesVersion = "v1.30.4"
 	ConstTerraformVersion  = "1.5.2"
 )
 
@@ -39,9 +39,9 @@ var ProjectApplyActions = [...]string{
 
 // ProjectK8sVersions define supported Kubernetes versions.
 var ProjectK8sVersions = []string{
-	"v1.29.0 - v1.29.5",
-	"v1.28.0 - v1.28.10",
-	"v1.27.0 - v1.27.14",
+	"v1.30.0 - v1.30.4",
+	"v1.29.0 - v1.29.7",
+	"v1.28.0 - v1.28.12",
 }
 
 // ProjectOsPresets is a list of available OS distros.

--- a/pkg/models/config/kubernetes_test.go
+++ b/pkg/models/config/kubernetes_test.go
@@ -10,10 +10,7 @@ import (
 )
 
 func TestKubernetesVersion(t *testing.T) {
-	assert.NoError(t, KubernetesVersion("v1.27.0").Validate())
-	assert.NoError(t, KubernetesVersion("v1.27.5").Validate())
-	assert.NoError(t, KubernetesVersion("v1.28.0").Validate())
-	assert.NoError(t, KubernetesVersion("v1.28.5").Validate())
+	assert.NoError(t, KubernetesVersion("v1.30.0").Validate())
 	assert.ErrorContains(t, KubernetesVersion("v1.1.1").Validate(), "Unsupported Kubernetes version")
 	assert.ErrorContains(t, KubernetesVersion("v1.28.100").Validate(), "Unsupported Kubernetes version")
 }


### PR DESCRIPTION
Bump Kubespray to `2.26.0` and add Kubernetes `1.30`.
Kubernetes `1.27` is no longer supported.