### PR TITLE
runner-setup: Install missing packages

### DIFF
--- a/.github/actions/runner-setup/action.yml
+++ b/.github/actions/runner-setup/action.yml
@@ -10,14 +10,16 @@ runs:
         sudo apt update
         sudo apt-get install -y --no-install-recommends \
           curl \
+          dnsmasq \
           libvirt-clients \
           libvirt-daemon-system \
           mkisofs \
-          virtualenv \
           python3-pip \
           qemu-utils \
           qemu-system \
-          spice-client-gtk
+          qemu-system-modules-spice \
+          spice-client-gtk \
+          virtualenv
 
     - name: Configure libvirt
       shell: bash


### PR DESCRIPTION
Latest GH Ubuntu runner is now `24.04`, which comes with a different set of default packages.