### PR TITLE
Change default graphics type for Terraform vm module

### DIFF
--- a/embed/terraform/modules/vm/vm.tf
+++ b/embed/terraform/modules/vm/vm.tf
@@ -106,7 +106,7 @@ resource "libvirt_domain" "vm_domain" {
   }
 
   graphics {
-    type        = "spice"
+    type        = "vnc"
     listen_type = "address"
     autoport    = true
   }


### PR DESCRIPTION
Set 'vnc' as default graphics type for compatibility with RedHat 9+ after Spice deprecation