### PR TITLE
forced use of the active python when calling virtualenv

### DIFF
--- a/pkg/tools/virtualenv/virtualenv.go
+++ b/pkg/tools/virtualenv/virtualenv.go
@@ -55,14 +55,25 @@ func (e *VirtualEnv) Init() error {
 
 // create creates virtual environment if it does not yet exist.
 func (e *VirtualEnv) create() error {
-	wd := path.Dir(e.path)
 
-	err := os.MkdirAll(wd, os.ModePerm)
+	// First find the active Python binary.
+	// Eg. if virtualenv is installed system-wide, then simply calling
+	// "virtualenv -p python3" may use a version of python that is not
+	// compatible with the required ansible version. This allows a
+	// user-installed python to be used instead.
+	pythonPath, err := exec.LookPath("python3")
 	if err != nil {
 		return err
 	}
 
-	cmd := exec.Command("virtualenv", "-p", "python3", e.path)
+	wd := path.Dir(e.path)
+
+	err = os.MkdirAll(wd, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("virtualenv", "-p", pythonPath, e.path)
 	cmd.Dir = wd
 
 	if ui.Debug() {


### PR DESCRIPTION
If you are on ubuntu20 and have installed virtualenv via apt (apt-get install python3-virtualenv), then the command that kubitect uses to create a virtualenv - `virtualenv -p python` - will use the system python which is python-3.8.10. But that is not compatible with the required ansible version which is set in the requirements.txt to be ==9.3.0 and you will get an error at cluster creation time.

If you use pyenv or similar, then you can install and use a later compatible python version, but without this change, even though this later python could be the active python in the current shell, the system call to virtualenv will continue to use the system python.

You could say that, if you are using pyenv anyway, then you could install virtualenv to the active python with `pip install virtualenv` which would also solve the problem. This change covers the case where someone may not be aware of that possibility and, having followed an instruction to use `apt-get install`, would otherwise be stuck with the error.

To see the error, you can use pyenv to install python 3.8.10, then `pyenv global 3.8.10` to make it active, then `pip install ansible==9.3.0`.