### PR TITLE
Fix Using Static IPs With NAT

### DIFF
--- a/embed/terraform/modules/vm/vm.tf
+++ b/embed/terraform/modules/vm/vm.tf
@@ -19,7 +19,7 @@ resource "libvirt_cloudinit_disk" "cloud_init" {
     ssh_public_key = data.local_file.ssh_public_key.content
   })
 
-  network_config = templatefile(var.vm_ip != null
+  network_config = templatefile(var.network_mode != "nat" && var.vm_ip != null
     ? "./templates/cloud_init/cloud_init_network_static.tpl"
     : "./templates/cloud_init/cloud_init_network_dhcp.tpl"
     , {

--- a/embed/terraform/templates/cloud_init/cloud_init_network_static.tpl
+++ b/embed/terraform/templates/cloud_init/cloud_init_network_static.tpl
@@ -1,7 +1,7 @@
 version: 2
 ethernets:
   ${network_interface}:
-    dhcp4: true
+    dhcp4: false
     dhcp6: false
     addresses: [${vm_cidr}]
     gateway4: ${network_gateway}


### PR DESCRIPTION
When a static IP is configured and the network mode is set to NAT the IP is set in the `network_interface.addresses` field of the domain which adds it to the libvirt DHCP server. In that case the netplan config in the guest OS should be set to dynamic to use the DHCP address.

Changing this means that DHCP can be disabled in the static netplan config which was causing duplicate IP addresses to be assigned.  I.e. if a DHCP server is running in the subnet then the VM will use the static IP address and the one assigned by DHCP.