### PR TITLE
tf/versions: Bump dmavicar/libvirt version to 0.8.3

### DIFF
--- a/embed/terraform/versions.tf
+++ b/embed/terraform/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.8.0"
+      version = "0.8.3"
     }
   }
 }


### PR DESCRIPTION
Hi!
I suggest you to update terraform provider version to 0.8.3
This update not break terraform files compability and [fix SSH connection issues](https://github.com/MusicDin/kubitect/issues/272)
